### PR TITLE
Custom and interactive install

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,6 +405,8 @@ dependencies = [
  "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winreg 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/src/rustup-cli/common.rs
+++ b/src/rustup-cli/common.rs
@@ -33,15 +33,14 @@ pub enum Confirm {
     Yes, No, Advanced
 }
 
-pub fn confirm_advanced(question: &str, default: Confirm) -> Result<Confirm> {
-    print!("{} ", question);
+pub fn confirm_advanced(default: Confirm) -> Result<Confirm> {
     let _ = std::io::stdout().flush();
     let input = try!(read_line());
 
     let r = match &*input {
-        "y" | "Y" => Confirm::Yes,
-        "n" | "N" => Confirm::No,
-        "a" | "A" => Confirm::Advanced,
+        "y" | "Y" | "yes" => Confirm::Yes,
+        "n" | "N" | "no" => Confirm::No,
+        "a" | "A" | "advanced" => Confirm::Advanced,
         "" => default,
         _ => Confirm::No,
     };
@@ -49,6 +48,40 @@ pub fn confirm_advanced(question: &str, default: Confirm) -> Result<Confirm> {
     println!("");
 
     Ok(r)
+}
+
+pub fn question_str(question: &str, default: &str) -> Result<String> {
+    println!("{}", question);
+    let _ = std::io::stdout().flush();
+    let input = try!(read_line());
+
+    println!("");
+
+    if input.is_empty() {
+        Ok(default.to_string())
+    } else {
+        Ok(input)
+    }
+}
+
+pub fn question_bool(question: &str, default: bool) -> Result<bool> {
+    println!("{}", question);
+
+    let _ = std::io::stdout().flush();
+    let input = try!(read_line());
+
+    println!("");
+
+    if input.is_empty() {
+        Ok(default)
+    } else {
+        match &*input {
+            "y" | "Y" | "yes" => Ok(true),
+            "n" | "N" | "no" => Ok(false),
+            _ => Ok(default)
+        }
+    }
+
 }
 
 pub fn read_line() -> Result<String> {

--- a/src/rustup-cli/common.rs
+++ b/src/rustup-cli/common.rs
@@ -29,6 +29,28 @@ pub fn confirm(question: &str, default: bool) -> Result<bool> {
     Ok(r)
 }
 
+pub enum Confirm {
+    Yes, No, Advanced
+}
+
+pub fn confirm_advanced(question: &str, default: Confirm) -> Result<Confirm> {
+    print!("{} ", question);
+    let _ = std::io::stdout().flush();
+    let input = try!(read_line());
+
+    let r = match &*input {
+        "y" | "Y" => Confirm::Yes,
+        "n" | "N" => Confirm::No,
+        "a" | "A" => Confirm::Advanced,
+        "" => default,
+        _ => Confirm::No,
+    };
+
+    println!("");
+
+    Ok(r)
+}
+
 pub fn read_line() -> Result<String> {
     let stdin = std::io::stdin();
     let stdin = stdin.lock();

--- a/src/rustup-cli/main.rs
+++ b/src/rustup-cli/main.rs
@@ -96,10 +96,14 @@ fn run_multirust() -> Result<()> {
             // ~/.multirust/tmp/multirust-$random, and execute it with
             // `self install` as the arguments.  FIXME: Verify this
             // works.
+            let opts = self_update::InstallOpts {
+                default_toolchain: "stable".to_string(),
+                no_modify_path: false,
+            };
             if cfg!(windows) {
-                self_update::install(false, false, "stable", false)
+                self_update::install(false, false, opts)
             } else {
-                self_update::install(true, false, "stable", false)
+                self_update::install(true, false, opts)
             }
         }
         Some(_) => {

--- a/src/rustup-cli/main.rs
+++ b/src/rustup-cli/main.rs
@@ -97,9 +97,9 @@ fn run_multirust() -> Result<()> {
             // `self install` as the arguments.  FIXME: Verify this
             // works.
             if cfg!(windows) {
-                self_update::install(false, false, "stable")
+                self_update::install(false, false, "stable", false)
             } else {
-                self_update::install(true, false, "stable")
+                self_update::install(true, false, "stable", false)
             }
         }
         Some(_) => {

--- a/src/rustup-cli/self_update.rs
+++ b/src/rustup-cli/self_update.rs
@@ -148,7 +148,8 @@ fn canonical_cargo_home() -> Result<String> {
 /// Installing is a simple matter of coping the running binary to
 /// CARGO_HOME/bin, hardlinking the various Rust tools to it,
 /// and and adding CARGO_HOME/bin to PATH.
-pub fn install(no_prompt: bool, verbose: bool, default: &str) -> Result<()> {
+pub fn install(no_prompt: bool, verbose: bool,
+               default: &str, no_modify_path: bool) -> Result<()> {
 
     if !no_prompt {
         let ref msg = try!(pre_install_msg());
@@ -161,7 +162,9 @@ pub fn install(no_prompt: bool, verbose: bool, default: &str) -> Result<()> {
     let install_res: Result<()> = (|| {
         try!(cleanup_legacy());
         try!(install_bins());
-        try!(do_add_to_path(&get_add_path_methods()));
+        if !no_modify_path {
+            try!(do_add_to_path(&get_add_path_methods()));
+        }
         try!(maybe_install_rust(default, verbose));
 
         if cfg!(unix) {

--- a/src/rustup-cli/setup_mode.rs
+++ b/src/rustup-cli/setup_mode.rs
@@ -27,14 +27,18 @@ pub fn main() -> Result<()> {
              .long("default-toolchain")
              .takes_value(true)
              .possible_values(&["stable", "beta", "nightly"])
-             .help("Choose a default toolchain to install"));
+             .help("Choose a default toolchain to install"))
+        .arg(Arg::with_name("no-modify-path")
+             .long("no-modify-path")
+             .help("Don't configure the PATH environment variable"));
 
     let matches = cli.get_matches();
     let no_prompt = matches.is_present("no-prompt");
     let verbose = matches.is_present("verbose");
     let default = matches.value_of("default-toolchain").unwrap_or("stable");
+    let no_modify_path = matches.is_present("no-modify-path");
 
-    try!(self_update::install(no_prompt, verbose, default));
+    try!(self_update::install(no_prompt, verbose, default, no_modify_path));
 
     Ok(())
 }

--- a/src/rustup-cli/setup_mode.rs
+++ b/src/rustup-cli/setup_mode.rs
@@ -1,5 +1,5 @@
 use std::env;
-use self_update;
+use self_update::{self, InstallOpts};
 use rustup::Result;
 use clap::{App, Arg};
 use common;
@@ -35,10 +35,15 @@ pub fn main() -> Result<()> {
     let matches = cli.get_matches();
     let no_prompt = matches.is_present("no-prompt");
     let verbose = matches.is_present("verbose");
-    let default = matches.value_of("default-toolchain").unwrap_or("stable");
+    let default_toolchain = matches.value_of("default-toolchain").unwrap_or("stable");
     let no_modify_path = matches.is_present("no-modify-path");
 
-    try!(self_update::install(no_prompt, verbose, default, no_modify_path));
+    let opts = InstallOpts {
+        default_toolchain: default_toolchain.to_owned(),
+        no_modify_path: no_modify_path,
+    };
+
+    try!(self_update::install(no_prompt, verbose, opts));
 
     Ok(())
 }

--- a/src/rustup-mock/Cargo.toml
+++ b/src/rustup-mock/Cargo.toml
@@ -20,3 +20,19 @@ openssl = "0.7.2"
 itertools = "0.4.1"
 tar = "0.4.0"
 toml = "0.1.27"
+
+[target.x86_64-pc-windows-gnu.dependencies]
+winapi = "0.2.4"
+winreg = "0.3.2"
+
+[target.x86_64-pc-windows-msvc.dependencies]
+winapi = "0.2.4"
+winreg = "0.3.2"
+
+[target.i686-pc-windows-gnu.dependencies]
+winapi = "0.2.4"
+winreg = "0.3.2"
+
+[target.i686-pc-windows-msvc.dependencies]
+winapi = "0.2.4"
+winreg = "0.3.2"

--- a/tests/cli-install-interactive.rs
+++ b/tests/cli-install-interactive.rs
@@ -78,7 +78,7 @@ fn blank_lines_around_stderr_log_output_install() {
         // then log output on stderr, then an explicit blank line on stdout
         // before printing $toolchain installed
         assert!(out.stdout.contains(r"
-Continue? (Y/n) 
+Press the Enter key to install Rust. 
 
   stable installed - 1.1.0 (hash-s-2)
 
@@ -88,7 +88,7 @@ Rust is installed now. Great!
 }
 
 #[test]
-fn blank_lines_around_log_output_update() {
+fn blank_lines_around_stderr_log_output_update() {
     setup(&|config| {
         run_input(config, &["rustup-setup"], "\n\n");
         let out = run_input(config, &["rustup-setup"], "\n\n");
@@ -96,7 +96,9 @@ fn blank_lines_around_log_output_update() {
         // Here again the user generates one blank line, then there
         // are lines of stderr logs, then one blank line on stdout.
         assert!(out.stdout.contains(r"
-Continue? (Y/n) 
+Press the Enter key to install Rust. 
+
+  stable unchanged - 1.1.0 (hash-s-2)
 
 Rust is installed now. Great!
 "));

--- a/tests/cli-install-interactive.rs
+++ b/tests/cli-install-interactive.rs
@@ -1,0 +1,125 @@
+//! Tests of the interactive console installer
+
+extern crate rustup_mock;
+extern crate rustup_utils;
+#[macro_use]
+extern crate lazy_static;
+extern crate scopeguard;
+
+use std::sync::Mutex;
+use std::process::Stdio;
+use std::io::Write;
+use rustup_mock::clitools::{self, Config, Scenario,
+                               SanitizedOutput};
+use rustup_mock::{get_path, restore_path};
+
+pub fn setup(f: &Fn(&Config)) {
+    clitools::setup(Scenario::SimpleV2, &|config| {
+        // Lock protects environment variables
+        lazy_static! {
+            static ref LOCK: Mutex<()> = Mutex::new(());
+        }
+        let _g = LOCK.lock();
+
+        // An windows these tests mess with the user's PATH. Save
+        // and restore them here to keep from trashing things.
+        let saved_path = get_path();
+        let _g = scopeguard::guard(saved_path, |p| restore_path(p));
+
+        f(config);
+    });
+}
+
+fn run_input(config: &Config, args: &[&str], input: &str) -> SanitizedOutput {
+    let mut cmd = clitools::cmd(config, &args[0], &args[1..]);
+    clitools::env(config, &mut cmd);
+
+    cmd.stdin(Stdio::piped());
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+    let mut child = cmd.spawn().unwrap();
+
+    child.stdin.as_mut().unwrap().write_all(input.as_bytes()).unwrap();
+    let out = child.wait_with_output().unwrap();
+
+    SanitizedOutput {
+        ok: out.status.success(),
+        stdout: String::from_utf8(out.stdout).unwrap(),
+        stderr: String::from_utf8(out.stderr).unwrap(),
+    }
+}
+
+#[test]
+fn smoke_test() {
+    setup(&|config| {
+        let out = run_input(config, &["rustup-setup"], "\n\n");
+        assert!(out.ok);
+    });
+}
+
+#[test]
+fn update() {
+    setup(&|config| {
+        run_input(config, &["rustup-setup"], "\n\n");
+        let out = run_input(config, &["rustup-setup"], "\n\n");
+        assert!(out.ok);
+    });
+}
+
+// Testing that the right number of blank lines are printed after the
+// 'pre-install' message and before the 'post-install' messag.
+#[test]
+fn blank_lines_around_stderr_log_output_install() {
+    setup(&|config| {
+        let out = run_input(config, &["rustup-setup"], "\n\n");
+
+        // During an interactive session, after "Continue?"
+        // there is a blank line that comes from the user pressing enter,
+        // then log output on stderr, then an explicit blank line on stdout
+        // before printing $toolchain installed
+        assert!(out.stdout.contains(r"
+Continue? (Y/n) 
+
+  stable installed - 1.1.0 (hash-s-2)
+
+Rust is installed now. Great!
+"));
+    });
+}
+
+#[test]
+fn blank_lines_around_log_output_update() {
+    setup(&|config| {
+        run_input(config, &["rustup-setup"], "\n\n");
+        let out = run_input(config, &["rustup-setup"], "\n\n");
+
+        // Here again the user generates one blank line, then there
+        // are lines of stderr logs, then one blank line on stdout.
+        assert!(out.stdout.contains(r"
+Continue? (Y/n) 
+
+Rust is installed now. Great!
+"));
+    });
+}
+
+#[test]
+fn user_says_nope() {
+    setup(&|config| {
+        let out = run_input(config, &["rustup-setup"], "n\n\n");
+        assert!(out.ok);
+        assert!(!config.cargodir.join("bin").exists());
+    });
+}
+
+#[test]
+fn with_no_modify_path() {
+}
+
+#[test]
+fn with_non_default_toolchain() {
+}
+
+#[test]
+fn with_no_modify_path_and_non_default_toolchain() {
+}

--- a/tests/cli-install-interactive.rs
+++ b/tests/cli-install-interactive.rs
@@ -114,6 +114,15 @@ fn user_says_nope() {
 
 #[test]
 fn with_no_modify_path() {
+    setup(&|config| {
+        let out = run_input(config, &["rustup-setup", "--no-modify-path"], "\n\n");
+        assert!(out.ok);
+        assert!(out.stdout.contains("This path needs to be in your PATH environment variable"));
+
+        if cfg!(unix) {
+            assert!(!config.homedir.join(".profile").exists());
+        }
+    });
 }
 
 #[test]

--- a/tests/cli-self-update.rs
+++ b/tests/cli-self-update.rs
@@ -429,7 +429,7 @@ fn uninstall_removes_path() {
 fn install_doesnt_modify_path_if_passed_no_modify_path() {
     setup(&|config| {
         let ref profile = config.homedir.join(".profile");
-        expect_ok(config, &["rustup-setup", "-y", "--no-modify-path"]);
+        expect_ok(config, &["rustup-init", "-y", "--no-modify-path"]);
         assert!(!profile.exists());
     });
 }
@@ -437,12 +437,15 @@ fn install_doesnt_modify_path_if_passed_no_modify_path() {
 #[test]
 #[cfg(windows)]
 fn install_doesnt_modify_path_if_passed_no_modify_path() {
+    use winreg::RegKey;
+    use winapi::*;
+
     setup(&|config| {
         let root = RegKey::predef(HKEY_CURRENT_USER);
         let environment = root.open_subkey_with_flags("Environment", KEY_READ | KEY_WRITE).unwrap();
         let old_path = environment.get_raw_value("PATH").unwrap();
 
-        expect_ok(config, &["rustup-setup", "-y", "--no-modify-path"]);
+        expect_ok(config, &["rustup-init", "-y", "--no-modify-path"]);
 
         let root = RegKey::predef(HKEY_CURRENT_USER);
         let environment = root.open_subkey_with_flags("Environment", KEY_READ | KEY_WRITE).unwrap();
@@ -733,7 +736,7 @@ fn reinstall_exact() {
         expect_ok_ex(config, &["rustup-init", "-y"],
 r"
 ",
-r"info: updating existing installation
+r"info: updating existing rustup installation
 "
                   );
     });
@@ -752,7 +755,7 @@ fn produces_env_file_on_unix() {
         assert!(cmd.output().unwrap().status.success());
         let ref envfile = config.homedir.join(".cargo/env");
         let envfile = raw::read_file(envfile).unwrap();
-        assert_eq!(r#"export PATH="$HOME/.cargo/bin:$PATH""#, envfile);
+        assert!(envfile.contains(r#"export PATH="$HOME/.cargo/bin:$PATH""#));
     });
 }
 

--- a/tests/cli-self-update.rs
+++ b/tests/cli-self-update.rs
@@ -460,6 +460,35 @@ fn uninstall_removes_path() {
     });
 }
 
+
+#[test]
+#[cfg(unix)]
+fn install_doesnt_modify_path_if_passed_no_modify_path() {
+    setup(&|config| {
+        let ref profile = config.homedir.join(".profile");
+        expect_ok(config, &["rustup-setup", "-y", "--no-modify-path"]);
+        assert!(!profile.exists());
+    });
+}
+
+#[test]
+#[cfg(windows)]
+fn install_doesnt_modify_path_if_passed_no_modify_path() {
+    setup(&|config| {
+        let root = RegKey::predef(HKEY_CURRENT_USER);
+        let environment = root.open_subkey_with_flags("Environment", KEY_READ | KEY_WRITE).unwrap();
+        let old_path = environment.get_raw_value("PATH").unwrap();
+
+        expect_ok(config, &["rustup-setup", "-y", "--no-modify-path"]);
+
+        let root = RegKey::predef(HKEY_CURRENT_USER);
+        let environment = root.open_subkey_with_flags("Environment", KEY_READ | KEY_WRITE).unwrap();
+        let new_path = environment.get_raw_value("PATH").unwrap();
+
+        assert!(old_path == new_path);
+    });
+}
+
 #[test]
 fn update_exact() {
     update_setup(&|config, _| {


### PR DESCRIPTION
This does a few things to make installation customizable.

The `--no-modify-path` flag disables `PATH` modification. `rustup-setup.sh` passes its arguments to `rustup-setup.exe`.

During the default interactive installation you can press "a" to enter "advanced installation", which just asks you the values of the two things that can be configured (path modification and default toolchain). We need this feature because it's the only way to change the installation options without finding out the command line options and starting installation over.

[Here's what it looks like in action](http://showterm.io/47a96fc6d1e94602bbb0e#fast).

It could be a lot nicer still, but this is all the features I expect.

Fixes https://github.com/rust-lang-nursery/multirust-rs/issues/271, https://github.com/rust-lang-nursery/multirust-rs/issues/170.