### PR TITLE
Fix build status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,5 +460,5 @@ additional terms or conditions.
 <!-- Badges -->
 [travis-build-status]: https://travis-ci.org/rust-lang-nursery/rustup.rs
 [travis-build-status-svg]: https://img.shields.io/travis/rust-lang-nursery/rustup.rs.svg
-[appveyor-build-status]: https://ci.appveyor.com/project/diggsey/multirust-rs
-[appveyor-build-status-svg]: https://img.shields.io/appveyor/ci/diggsey/multirust-rs.svg
+[appveyor-build-status]: https://ci.appveyor.com/project/brson/rustup-rs
+[appveyor-build-status-svg]: https://img.shields.io/appveyor/ci/brson/rustup-rs.svg

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # rustup: the Rust toolchain installer
 
-[![Build Status](https://travis-ci.org/rust-lang-nursery/multirust-rs.svg?branch=master)](https://travis-ci.org/rust-lang-nursery/multirust-rs)
-[![Build status](https://ci.appveyor.com/api/projects/status/vyiu5qfallpo0n6c/branch/master?svg=true)](https://ci.appveyor.com/project/brson/multirust-rs/branch/master)
+| Build Status |                                                                              |
+|--------------|------------------------------------------------------------------------------|
+| Travis       | [![Travis Build Status][travis-build-status-svg]][travis-build-status]       |
+| AppVeyor     | [![AppVeyor Build Status][appveyor-build-status-svg]][appveyor-build-status] |
 
 *rustup* installs [The Rust Programming Language] from the official
 release channels, enabling you to easily switch between stable, beta,
@@ -454,3 +456,9 @@ Unless you explicitly state otherwise, any contribution intentionally
 submitted for inclusion in the work by you, as defined in the
 Apache-2.0 license, shall be dual licensed as above, without any
 additional terms or conditions.
+
+<!-- Badges -->
+[travis-build-status]: https://travis-ci.org/rust-lang-nursery/rustup.rs
+[travis-build-status-svg]: https://img.shields.io/travis/rust-lang-nursery/rustup.rs.svg
+[appveyor-build-status]: https://ci.appveyor.com/project/diggsey/multirust-rs
+[appveyor-build-status-svg]: https://img.shields.io/appveyor/ci/diggsey/multirust-rs.svg


### PR DESCRIPTION
Also, move the badges into a table and change the badge graphics to SVGs served via [shields.io](http://shields.io/)

I'm pretty certain that the AppVeyor graphic and URL point to the old repository's build status so if someone could provide me with the right URL I'll go ahead and update it.