### PR TITLE
pass rustup-setup.sh arguments to rustup-setup

### DIFF
--- a/rustup-setup.sh
+++ b/rustup-setup.sh
@@ -56,7 +56,7 @@ main() {
         err "/dev/tty does not exist"
     fi
 
-    run "$_file" < /dev/tty
+    run "$_file" "$@" < /dev/tty
 
     local _retval=$?
 


### PR DESCRIPTION
this would let us call

```
curl https://sh.rustup.rs -sSf | sh -s -- -y
```

to install rustup without prompting.

closes #297

---

Test it with

```
curl https://raw.githubusercontent.com/japaric/multirust-rs/pass-args/rustup-setup.sh -sSf | sh -s -- -y
```

r? @brson
cc @TyOverby