### PR TITLE
Mentioned Visual C++ Build Tools 2015

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ toolchain] use the GNU build.
 
 MSVC builds of Rust additionally require an [installation of Visual
 Studio 2013 (or later) or the Visual C++ Build Tools 2015][vs] so
-rustc can use its linker. for Visual Studio, make sure to check
+rustc can use its linker. For Visual Studio, make sure to check
 the "C++ tools" option. No additional software installation is
 necessary for basic use of the GNU build.
 

--- a/README.md
+++ b/README.md
@@ -290,7 +290,8 @@ Rust; for interop with GNU software built using the [MinGW/MSYS2
 toolchain] use the GNU build.
 
 MSVC builds of Rust additionally require an [installation of Visual
-Studio 2013 (or later)][vs] so rustc can use its linker. Make sure to check
+Studio 2013 (or later) or the Visual C++ Build Tools 2015][vs] so
+rustc can use its linker. for Visual Studio, make sure to check
 the "C++ tools" option. No additional software installation is
 necessary for basic use of the GNU build.
 
@@ -410,15 +411,18 @@ platform of your choice:
 
 <a name="vs2015">†</a>
 MSVC builds of `rustup` additionally require an [installation of
-Visual Studio 2015](https://www.visualstudio.com/downloads). Make sure
-to check the "C++ tools" option. No additional software installation
-is necessary for basic use of the GNU build.
+Visual Studio 2015 or the Visual C++ Build Tools 2015][vs]. For
+Visual Studio, make sure to check the "C++ tools" option. No
+additional software installation is necessary for basic use of
+the GNU build.
 
 To install from source just run `cargo run --release`. Note that
 currently rustup only builds on nightly Rust, and that after
 installation the rustup toolchains will supercede any pre-existing
 toolchains by prepending `~/.cargo/bin` to the `PATH` environment
 variable.
+
+[vs]: https://www.visualstudio.com/downloads
 
 ## Security
 


### PR DESCRIPTION
There is a Visual C++ Build Tools 2015 that installs just the C++ build tools without the full Visual Studio. It includes the necessary linker to build Rust MSVC. It's on the same downloads page, under "Tools for Visual Studio 2015". I think a lot of people would be happy to know of a more lightweight installer option, hopefully it's not confusing.
More info here: https://blogs.msdn.microsoft.com/vcblog/2016/03/31/announcing-the-official-release-of-the-visual-c-build-tools-2015/