### PR TITLE
add commit hash to the output of -V

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ keywords = ["multirust", "install", "proxy"]
 
 license = "MIT OR Apache-2.0"
 
+build = "build.rs"
+
 [dependencies]
 rustup-dist = { path = "src/rustup-dist" }
 rustup-utils = { path = "src/rustup-utils" }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,51 @@
+use std::env;
+use std::error::Error;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::Command;
+
+struct Ignore;
+
+impl<E> From<E> for Ignore
+    where E: Error
+{
+    fn from(_: E) -> Ignore {
+        Ignore
+    }
+}
+
+fn main() {
+    let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
+
+    File::create(out_dir.join("commit-info.txt"))
+        .unwrap()
+        .write_all(commit_info().as_bytes())
+        .unwrap();
+}
+
+// Try to get hash and date of the last commit on a best effort basis. If anything goes wrong
+// (git not installed or if this is not a git repository) just return an empty string.
+fn commit_info() -> String {
+    match (commit_hash(), commit_date()) {
+        (Ok(hash), Ok(date)) => format!(" ({} {})", hash.trim_right(), date),
+        _ => String::new(),
+    }
+}
+
+fn commit_hash() -> Result<String, Ignore> {
+    Ok(try!(String::from_utf8(try!(Command::new("git")
+                                       .args(&["rev-parse", "--short", "HEAD"])
+                                       .output())
+                                  .stdout)))
+}
+
+fn commit_date() -> Result<String, Ignore> {
+    Ok(try!(String::from_utf8(try!(Command::new("git")
+                                       .args(&["log",
+                                               "-1",
+                                               "--date=short",
+                                               "--pretty=format:%cd"])
+                                       .output())
+                                  .stdout)))
+}

--- a/src/rustup-cli/common.rs
+++ b/src/rustup-cli/common.rs
@@ -337,7 +337,7 @@ pub fn list_overrides(cfg: &Cfg) -> Result<()> {
 
 
 pub fn version() -> &'static str {
-    option_env!("CARGO_PKG_VERSION").unwrap_or("unknown")
+    concat!(env!("CARGO_PKG_VERSION"), include_str!(concat!(env!("OUT_DIR"), "/commit-info.txt")))
 }
 
 fn split_override<T: FromStr>(s: &str, separator: char) -> Option<(T, T)> {


### PR DESCRIPTION
closes #319

Example output:

```
$ cargo build && target/debug/rustup-init -V
multirust-setup 0.1.7 (213d809 2016-04-20)

```