### PR TITLE
Adding rustc telemetry analysis

### DIFF
--- a/src/rustup-cli/common.rs
+++ b/src/rustup-cli/common.rs
@@ -1,6 +1,7 @@
 //! Just a dumping ground for cli stuff
 
 use rustup::{self, Cfg, Notification, Toolchain, UpdateStatus};
+use rustup::telemetry_analysis::TelemetryAnalysis;
 use errors::*;
 use rustup_utils::utils;
 use rustup_utils::notify::NotificationLevel;
@@ -351,6 +352,7 @@ fn split_override<T: FromStr>(s: &str, separator: char) -> Option<(T, T)> {
     })
 }
 
+
 pub fn report_error(e: &Error) {
     err!("{}", e);
 
@@ -381,4 +383,12 @@ pub fn report_error(e: &Error) {
 
         return false;
     }
+}
+
+pub fn show_telemetry(analysis: TelemetryAnalysis) -> Result<()> {
+    println!("Telemetry Analysis");
+
+    println!("{}", analysis);
+
+    Ok(())
 }

--- a/src/rustup/command.rs
+++ b/src/rustup/command.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 use std::env;
 use std::ffi::OsStr;
 use std::io::{self, Write, BufRead, BufReader};
@@ -60,7 +59,7 @@ fn telemetry_rustc<S: AsRef<OsStr>>(mut cmd: Command, args: &[S], cfg: &Cfg) -> 
             let mut buffer = String::new();
             // Chose a HashSet instead of a Vec to avoid calls to sort() and dedup().
             // The HashSet should be faster if there are a lot of errors, too.
-            let mut errors: HashSet<String> = HashSet::new();
+            let mut errors: Vec<String> = Vec::new();
 
             let stderr = io::stderr();
             let mut handle = stderr.lock();
@@ -75,7 +74,7 @@ fn telemetry_rustc<S: AsRef<OsStr>>(mut cmd: Command, args: &[S], cfg: &Cfg) -> 
                     None => continue,
                     Some(caps) => {
                         if caps.len() > 0 {
-                            let _ = errors.insert(caps.name("error").unwrap_or("").to_owned());
+                            let _ = errors.push(caps.name("error").unwrap_or("").to_owned());
                         }
                     }
                 };

--- a/src/rustup/config.rs
+++ b/src/rustup/config.rs
@@ -15,6 +15,7 @@ use rustup_utils::utils;
 use override_db::OverrideDB;
 use toolchain::{Toolchain, UpdateStatus};
 use telemetry::{TelemetryMode};
+use telemetry_analysis::*;
 
 // Note: multirust-rs jumped from 2 to 12 to leave multirust.sh room to diverge
 pub const METADATA_VERSION: &'static str = "12";
@@ -458,5 +459,14 @@ impl Cfg {
         }
 
         TelemetryMode::Off
+    }
+
+    pub fn analyze_telemetry(&self) -> Result<TelemetryAnalysis> {
+        let mut t = TelemetryAnalysis::new(self.multirust_dir.join("telemetry"));
+
+        let events = try!(t.import_telemery());
+        try!(t.analyze_telemetry_events(&events));
+
+        Ok(t)
     }
 }

--- a/src/rustup/errors.rs
+++ b/src/rustup/errors.rs
@@ -60,5 +60,8 @@ error_chain! {
         TelemetryCleanupError {
             description("unable to remove old telemetry files")
         }
+        TelemetryAnalysisError {
+            description("error analyzing telemetry files")
+        }
     }
 }

--- a/src/rustup/lib.rs
+++ b/src/rustup/lib.rs
@@ -27,3 +27,4 @@ mod env_var;
 mod install;
 pub mod telemetry;
 pub mod command;
+pub mod telemetry_analysis;

--- a/src/rustup/telemetry.rs
+++ b/src/rustup/telemetry.rs
@@ -3,7 +3,6 @@ use time;
 use rustup_utils::{raw, utils};
 use rustc_serialize::json;
 
-use std::collections::HashSet;
 use std::fs;
 use std::path::PathBuf;
 
@@ -13,18 +12,24 @@ pub enum TelemetryMode {
     Off,
 }
 
-#[derive(RustcDecodable, RustcEncodable, Debug)]
+#[derive(RustcDecodable, RustcEncodable, Debug, Clone)]
 pub enum TelemetryEvent {
-    RustcRun { duration_ms: u64, exit_code: i32, errors: Option<HashSet<String>> },
+    RustcRun { duration_ms: u64, exit_code: i32, errors: Option<Vec<String>> },
     ToolchainUpdate { toolchain: String, success: bool } ,
     TargetAdd { toolchain: String, target: String, success: bool },
 }
 
 #[derive(RustcDecodable, RustcEncodable, Debug)]
-struct LogMessage {
+pub struct LogMessage {
     log_time_s: i64,
     event: TelemetryEvent,
     version: i32,
+}
+
+impl LogMessage {
+    pub fn get_event(&self) -> TelemetryEvent {
+        self.event.clone()
+    }
 }
 
 #[derive(Debug)]

--- a/src/rustup/telemetry_analysis.rs
+++ b/src/rustup/telemetry_analysis.rs
@@ -1,0 +1,319 @@
+use std::collections::HashMap;
+use std::fmt;
+use std::fs::File;
+use std::io::BufReader;
+use std::io::BufRead;
+use std::path::PathBuf;
+use itertools::Itertools;
+
+use errors::*;
+use telemetry::{LogMessage, TelemetryEvent};
+use rustc_serialize::json;
+
+pub struct TelemetryAnalysis {
+    telemetry_dir: PathBuf,
+    rustc_statistics: RustcStatistics,
+    rustc_success_statistics: RustcStatistics,
+    rustc_error_statistics: RustcStatistics,
+}
+
+pub struct RustcStatistics {
+    rustc_execution_count: u32,
+    compile_time_ms_total: u64,
+    compile_time_ms_mean: u64,
+    compile_time_ms_ntile_75: u64,
+    compile_time_ms_ntile_90: u64,
+    compile_time_ms_ntile_95: u64,
+    compile_time_ms_ntile_99: u64,
+    compile_time_ms_stdev: f64,
+    exit_codes_with_count: HashMap<i32, i32>,
+    error_codes_with_counts: HashMap<String, i32>,
+}
+
+impl RustcStatistics {
+    pub fn new() -> RustcStatistics {
+        RustcStatistics {
+            rustc_execution_count: 0u32,
+            compile_time_ms_total: 0u64,
+            compile_time_ms_mean: 0u64,
+            compile_time_ms_ntile_75: 0u64,
+            compile_time_ms_ntile_90: 0u64,
+            compile_time_ms_ntile_95: 0u64,
+            compile_time_ms_ntile_99: 0u64,
+            compile_time_ms_stdev: 0f64,
+            exit_codes_with_count: HashMap::new(),
+            error_codes_with_counts: HashMap::new()
+        }
+    }
+}
+
+impl fmt::Display for RustcStatistics {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut errors: String = String::new();
+        
+        if self.error_codes_with_counts.len() > 0 {
+            errors = "  rustc errors\n".to_owned();
+            for (error, count) in &self.error_codes_with_counts {
+                errors = errors + &format!("    '{}': {}\n", error, count);
+            }
+        }
+
+        let mut exits: String = String::new();
+
+        if self.exit_codes_with_count.len() > 0 {
+            exits = "  rustc exit codes\n".to_owned();
+
+            for (exit, count) in &self.exit_codes_with_count {
+                exits = exits + &format!("    {}: {}\n", exit, count);
+            }
+        }
+
+        write!(f, r"
+  Total compiles: {}
+  Compile Time (ms)
+    Total : {}
+    Mean  : {}
+    STDEV : {}
+    75th  : {}
+    90th  : {}
+    95th  : {}
+    99th  : {}
+
+{}
+
+{}",
+            self.rustc_execution_count,
+            self.compile_time_ms_total,
+            self.compile_time_ms_mean,
+            self.compile_time_ms_stdev,
+            self.compile_time_ms_ntile_75,
+            self.compile_time_ms_ntile_90,
+            self.compile_time_ms_ntile_95,
+            self.compile_time_ms_ntile_99,
+            errors,
+            exits
+        )
+    }
+}
+
+impl fmt::Display for TelemetryAnalysis {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, r"
+Overall rustc statistics:
+{}
+
+rustc successful execution statistics
+{}
+
+rustc error statistics
+{}",
+            self.rustc_statistics,
+            self.rustc_success_statistics,
+            self.rustc_error_statistics
+        )
+    }
+}
+
+impl TelemetryAnalysis {
+    pub fn new(telemetry_dir: PathBuf) -> TelemetryAnalysis {
+        TelemetryAnalysis { 
+            telemetry_dir: telemetry_dir,
+            rustc_statistics: RustcStatistics::new(),
+            rustc_success_statistics: RustcStatistics::new(),
+            rustc_error_statistics: RustcStatistics::new(),
+        }
+    }
+
+    pub fn import_telemery(&mut self) -> Result<Vec<TelemetryEvent>> {
+        let mut events: Vec<TelemetryEvent> = Vec::new();
+        let contents = try!(self.telemetry_dir.read_dir().chain_err(|| ErrorKind::TelemetryAnalysisError));
+
+        let mut telemetry_files: Vec<PathBuf> = Vec::new();
+
+        for c in contents {
+            let x = c.unwrap();
+            let filename = x.path().file_name().unwrap().to_str().unwrap().to_owned();
+
+            if filename.starts_with("log") && filename.ends_with("json") {
+                telemetry_files.push(x.path());
+                match self.read_telemetry_file(x.path()) {
+                    Ok(y) => events.extend(y),
+                    Err(e) => return Err(e),
+                };
+            }
+        }
+
+        Ok(events)
+    }
+
+    fn read_telemetry_file(&self, path: PathBuf) -> Result<Vec<TelemetryEvent>> {
+        let mut events: Vec<TelemetryEvent> = Vec::new();
+
+        let f = try!(File::open(&path).chain_err(|| ErrorKind::TelemetryAnalysisError));
+
+        let file = BufReader::new(&f);
+
+        for line in file.lines() {
+            use std::result;
+            use rustc_serialize::json::DecoderError;
+
+            let l = line.unwrap();
+            let log_message_result: result::Result<LogMessage, DecoderError> = json::decode(&l);
+
+            if log_message_result.is_ok() {
+                let log_message = log_message_result.unwrap();
+                let event: TelemetryEvent = log_message.get_event();
+                events.push(event);
+            }
+        }
+
+        Ok(events)
+    }
+
+    pub fn analyze_telemetry_events(&mut self, events: &Vec<TelemetryEvent>) -> Result<()> {
+        let mut rustc_durations = Vec::new();
+        let mut rustc_exit_codes = Vec::new();
+
+        let mut rustc_successful_durations = Vec::new();
+        
+        let mut rustc_error_durations = Vec::new();
+        let mut error_list: Vec<Vec<String>> = Vec::new();
+        let mut error_codes_with_counts: HashMap<String, i32> = HashMap::new();
+        
+        let mut toolchains = Vec::new();
+        let mut toolchains_with_errors = Vec::new();
+        let mut targets = Vec::new();
+        
+        let mut updated_toolchains = Vec::new();
+        let mut updated_toolchains_with_errors = Vec::new();
+
+        for event in events {
+            match event {
+                &TelemetryEvent::RustcRun{ duration_ms, ref exit_code, ref errors } => {
+                    self.rustc_statistics.rustc_execution_count += 1;
+                    rustc_durations.push(duration_ms);
+
+                    let exit_count = self.rustc_statistics.exit_codes_with_count.entry(*exit_code).or_insert(0);
+                    *exit_count += 1;
+
+                    rustc_exit_codes.push(exit_code);
+                    
+                    if errors.is_some() {
+                        let errors = errors.clone().unwrap();
+
+                        for e in &errors {
+                            let error_count = error_codes_with_counts.entry(e.to_owned()).or_insert(0);
+                            *error_count += 1;
+                        }
+
+                        error_list.push(errors);
+                        rustc_error_durations.push(duration_ms);                        
+                    } else {
+                        rustc_successful_durations.push(duration_ms);
+                    }
+                },
+                &TelemetryEvent::TargetAdd{ ref toolchain, ref target, success } => {
+                    toolchains.push(toolchain.to_owned());
+                    targets.push(target.to_owned());
+                    if !success {
+                        toolchains_with_errors.push(toolchain.to_owned());
+                    }
+                },
+                &TelemetryEvent::ToolchainUpdate{ ref toolchain, success } => {
+                    updated_toolchains.push(toolchain.to_owned());
+                    if !success {
+                        updated_toolchains_with_errors.push(toolchain.to_owned());
+                    }
+                },
+            }
+        };
+
+        self.rustc_statistics = compute_rustc_percentiles(&rustc_durations);
+        self.rustc_error_statistics = compute_rustc_percentiles(&rustc_error_durations);
+        self.rustc_error_statistics.error_codes_with_counts = error_codes_with_counts;
+        self.rustc_success_statistics = compute_rustc_percentiles(&rustc_successful_durations);
+
+        let error_list = error_list.into_iter().flatten();
+
+        for e in error_list {
+            let error_count = self.rustc_statistics.error_codes_with_counts.entry(e).or_insert(0);
+            *error_count += 1;
+        }
+
+        Ok(())
+    }
+}
+
+pub fn compute_rustc_percentiles(values: &Vec<u64>) -> RustcStatistics {
+    RustcStatistics {
+        rustc_execution_count: (values.len() as u32),
+        compile_time_ms_total: values.iter().fold(0, |sum, val| sum + val),
+        compile_time_ms_mean: mean(&values),
+        compile_time_ms_ntile_75: ntile(75, &values),
+        compile_time_ms_ntile_90: ntile(90, &values),
+        compile_time_ms_ntile_95: ntile(95, &values),
+        compile_time_ms_ntile_99: ntile(99, &values),
+        compile_time_ms_stdev: stdev(&values),
+        exit_codes_with_count: HashMap::new(),
+        error_codes_with_counts: HashMap::new()
+    }
+}
+
+pub fn ntile(percentile: i32, values: &Vec<u64>) -> u64 {
+    if values.len() == 0 {
+        return 0u64;
+    }
+
+    let mut values = values.clone();
+    values.sort();
+
+    let count = values.len() as f32;
+    let percentile = (percentile as f32) / 100f32;
+
+    let n = (count * percentile).ceil() - 1f32;
+    let n = n as usize;
+
+    values[n]
+}
+
+pub fn mean(values: &Vec<u64>) -> u64 {
+    if values.len() == 0 {
+        return 0u64;
+    }
+
+    let count = values.len() as f64;
+
+    let sum = values.iter().fold(0, |sum, val| sum + val) as f64;
+
+    (sum / count) as u64
+}
+
+pub fn variance(values: &Vec<u64>) -> f64 {
+    if values.len() == 0 {
+        return 0f64;
+    }
+
+    let mean = mean(&values);
+
+    let mut deviations: Vec<i64> = Vec::new();
+
+    for v in values.iter() {
+        let x = (*v as i64) - (mean as i64);
+
+        deviations.push(x * x);
+    }
+
+    let sum = deviations.iter().fold(0, |sum, val| sum + val) as f64;
+
+    sum / (values.len() as f64)
+}
+
+pub fn stdev(values: &Vec<u64>) -> f64 {
+    if values.len() == 0 {
+        return 0f64;
+    }
+
+    let variance = variance(&values);
+
+    variance.sqrt()
+}

--- a/tests/cli-exact.rs
+++ b/tests/cli-exact.rs
@@ -201,7 +201,7 @@ info: installing component 'rust-std' for '{0}'
 fn enable_telemetry() {
     setup(&|config| {
         expect_ok_ex(config,
-                     &["rustup", "telemetry", "on"],
+                     &["rustup", "telemetry", "enable"],
                      r"",
                      &format!("info: telemetry set to 'on'\n"));
     });
@@ -211,7 +211,7 @@ fn enable_telemetry() {
 fn disable_telemetry() {
     setup(&|config| {
         expect_ok_ex(config,
-                     &["rustup", "telemetry", "off"],
+                     &["rustup", "telemetry", "disable"],
                      r"",
                      &format!("info: telemetry set to 'off'\n"));
     });

--- a/tests/cli-misc.rs
+++ b/tests/cli-misc.rs
@@ -293,7 +293,7 @@ fn proxies_pass_empty_args() {
 fn enabling_telemetry_and_compiling_creates_log() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(config, &["rustup", "telemetry", "on"]);
+        expect_ok(config, &["rustup", "telemetry", "enable"]);
         expect_ok(config, &["rustc", "--version"]);
 
         let telemetry_dir = config.rustupdir.join("telemetry");
@@ -311,7 +311,7 @@ fn enabling_telemetry_and_compiling_creates_log() {
 fn telemetry_cleanup_removes_old_files() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(config, &["rustup", "telemetry", "on"]);
+        expect_ok(config, &["rustup", "telemetry", "enable"]);
 
         let telemetry_dir = config.rustupdir.join("telemetry");
 


### PR DESCRIPTION
This adds basic telemetry analysis. 

Sample output format is below. I took a stab at something just so I could see output as I was moving forward, I'm open to anything on making it prettier.

```
λ rustup telemetry analyze             
Telemetry Analysis                     
                                       
Overall rustc statistics:              
                                       
  Total compiles: 315                  
  Compile Time (ms)                    
    Total : 832403                     
    Mean  : 2642                       
    STDEV : 5176.235384174579          
    75th  : 3367                       
    90th  : 5773                       
    95th  : 12294                      
    99th  : 22623                      
                                       
  rustc errors                         
    'E0507': 3                         
    'E0382': 5                         
    'E0433': 4                         
    'E0277': 1                         
    'E0248': 1                         
    'E0425': 4                         
    'E0243': 1                         
    'E0412': 1                         
    'E0282': 2                         
    'E0308': 7                         
                                       
                                       
                                       
                                       
rustc successful execution statistics  
                                       
  Total compiles: 292                  
  Compile Time (ms)                    
    Total : 811826                     
    Mean  : 2780                       
    STDEV : 5352.005177936353          
    75th  : 3779                       
    90th  : 5818                       
    95th  : 12327                      
    99th  : 34488                      
                                       
                                       
                                       
                                       
                                       
rustc error statistics                 
                                       
  Total compiles: 23                   
  Compile Time (ms)                    
    Total : 20577                      
    Mean  : 894                        
    STDEV : 61.02351649337648          
    75th  : 878                        
    90th  : 997                        
    95th  : 1000                       
    99th  : 1054                       
                                       
  rustc errors                         
    'E0507': 3                         
    'E0248': 1                         
    'E0382': 5                         
    'E0433': 4                         
    'E0282': 2                         
    'E0308': 7                         
    'E0243': 1                         
    'E0277': 1                         
    'E0412': 1                         
    'E0425': 4 
```