### PR TITLE
Bump to 0.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 0.1.8
+
+* [Initial telemetry implementation (disabled)](https://github.com/rust-lang-nursery/rustup.rs/pull/289)
+* [Add hash to `--version`](https://github.com/rust-lang-nursery/rustup.rs/pull/347)
+* [Improve download progress](https://github.com/rust-lang-nursery/rustup.rs/pull/355)
+* [Completely overhaul error handling](https://github.com/rust-lang-nursery/rustup.rs/pull/358)
+* [Add armv7l support to www](https://github.com/rust-lang-nursery/rustup.rs/pull/359)
+* [Overhaul website](https://github.com/rust-lang-nursery/rustup.rs/pull/363)
+
 # 0.1.7
 
 * [Fix overrides for C:\](https://github.com/rust-lang-nursery/rustup.rs/pull/317).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,9 +1,9 @@
 [root]
 name = "rustup"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "clap 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "error-chain 0.1.7",
+ "error-chain 0.1.8",
  "hyper 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -13,9 +13,9 @@ dependencies = [
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.68 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustup-dist 0.1.7",
- "rustup-mock 0.1.7",
- "rustup-utils 0.1.7",
+ "rustup-dist 0.1.8",
+ "rustup-mock 0.1.8",
+ "rustup-utils 0.1.8",
  "scopeguard 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -128,7 +128,7 @@ dependencies = [
 
 [[package]]
 name = "error-chain"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "backtrace 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -440,17 +440,17 @@ dependencies = [
 
 [[package]]
 name = "rustup-dist"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
- "error-chain 0.1.7",
+ "error-chain 0.1.8",
  "flate2 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "ole32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.68 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustup-mock 0.1.7",
- "rustup-utils 0.1.7",
+ "rustup-mock 0.1.8",
+ "rustup-utils 0.1.8",
  "tar 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -459,7 +459,7 @@ dependencies = [
 
 [[package]]
 name = "rustup-mock"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "flate2 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -477,10 +477,10 @@ dependencies = [
 
 [[package]]
 name = "rustup-utils"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "advapi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "error-chain 0.1.7",
+ "error-chain 0.1.8",
  "hyper 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ole32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "rustup"
-version = "0.1.7"
+version = "0.1.8"
 authors = [ "Diggory Blake <diggsey@googlemail.com>" ]
 description = "multirust in rust - manage multiple rust installations with ease"
 

--- a/src/error-chain/Cargo.toml
+++ b/src/error-chain/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "error-chain"
-version = "0.1.7"
+version = "0.1.8"
 authors = [ "Brian Anderson <banderson@mozilla.com",
             "Paul Colomiets <paul@colomiets.name>",
             "Colin Kiegel <kiegel@gmx.de>"]

--- a/src/rustup-dist/Cargo.toml
+++ b/src/rustup-dist/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "rustup-dist"
-version = "0.1.7"
+version = "0.1.8"
 authors = [ "Diggory Blake <diggsey@googlemail.com>" ]
 description = "Installation from a Rust distribution server"
 build = "build.rs"

--- a/src/rustup-mock/Cargo.toml
+++ b/src/rustup-mock/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "rustup-mock"
-version = "0.1.7"
+version = "0.1.8"
 authors = [ "Diggory Blake <diggsey@googlemail.com>" ]
 description = "Test mocks for multirust"
 

--- a/src/rustup-utils/Cargo.toml
+++ b/src/rustup-utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "rustup-utils"
-version = "0.1.7"
+version = "0.1.8"
 authors = [ "Diggory Blake <diggsey@googlemail.com>" ]
 description = "multirust in rust - manage multiple rust installations with ease"
 


### PR DESCRIPTION
Changelog includes the unmerged [www PR](https://github.com/rust-lang-nursery/rustup.rs/pull/363). Once both land I'll publish this, probably tomorrow.