### PR TITLE
Don't make it an error for the self-update hash to be wrong

### DIFF
--- a/src/rustup-cli/self_update.rs
+++ b/src/rustup-cli/self_update.rs
@@ -35,7 +35,6 @@ use itertools::Itertools;
 use rustup::{NotifyHandler};
 use errors::*;
 use rustup_dist::dist;
-use rustup_dist;
 use rustup_utils::utils;
 use openssl::crypto::hash::{Type, Hasher};
 use std::env;
@@ -1077,11 +1076,8 @@ pub fn prepare_update() -> Result<Option<PathBuf>> {
 
     // Check that hash is correct
     if latest_hash != download_hash {
-        return Err(ErrorKind::Dist(rustup_dist::ErrorKind::ChecksumFailed {
-            url: url,
-            expected: latest_hash,
-            calculated: download_hash,
-        }).into());
+        info!("update not yet available. bug #364");
+        return Ok(None);
     }
 
     // Mark as executable


### PR DESCRIPTION
We've got problems with the updater and its hash being out
of sync. Thes patch considers a hash failure here a temporary
problem, prints a status message and exits with success.

cc #346

r? @alexcrichton 