### PR TITLE
rustup-mock has to be a regular dependency of rustup-dist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,6 +449,7 @@ dependencies = [
  "ole32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.68 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustup-mock 0.1.9",
  "rustup-utils 0.1.9",
  "tar 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/rustup-dist/Cargo.toml
+++ b/src/rustup-dist/Cargo.toml
@@ -25,9 +25,7 @@ walkdir = "0.1.5"
 toml = "0.1.27"
 rustup-utils = { path = "../rustup-utils", version = "0.1.9" }
 error-chain = { path = "../error-chain", version = "0.1.9" }
+rustup-mock = { path = "../rustup-mock", version = "0.1.9" }
 
 [lib]
 name = "rustup_dist"
-
-[dev-dependencies]
-rustup-mock = { path = "../rustup-mock", version = "0.1.9" }


### PR DESCRIPTION
I don't understand why. These are tests.

```
src/rustup-dist/tests/install.rs:3:1: 3:26 error: can't find crate for `rustup_mock` [E0463]
src/rustup-dist/tests/install.rs:3 extern crate rustup_mock;
                                   ^~~~~~~~~~~~~~~~~~~~~~~~~
error: aborting due to previous error
Build failed, waiting for other jobs to finish...
src/rustup-dist/tests/dist.rs:6:1: 6:26 error: can't find crate for `rustup_mock` [E0463]
src/rustup-dist/tests/dist.rs:6 extern crate rustup_mock;
                                ^~~~~~~~~~~~~~~~~~~~~~~~~
error: aborting due to previous error
error: Could not compile `rustup-dist`.
```

Fixes build failures on master. r? @alexcrichton Maybe you can see why this can't be a dev-dependency.