### PR TITLE
OpenSSL upgrades

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,7 @@ install:
 
       # For -msvc builds
       if ($env:TARGET -match "-msvc$") {
-        Start-FileDownload "http://www.npcglib.org/~stathis/downloads/openssl-1.0.2d-vs2015.7z" -FileName "openssl.7z"
+        Start-FileDownload "http://www.npcglib.org/~stathis/downloads/openssl-1.0.2g-vs2015.7z" -FileName "openssl.7z"
         7z x openssl.7z -o"C:\OpenSSL" | Out-Null
       }
 

--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -18,8 +18,8 @@ export LD_LIBRARY_PATH=/travis-rust/lib:$LD_LIBRARY_PATH
 # distribute (this can be changed by others of course).
 # ==============================================================================
 
-OPENSSL_VERS=1.0.2g
-OPENSSL_SHA256=b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33
+OPENSSL_VERS=1.0.2h
+OPENSSL_SHA256=1d4007e53aad94a5b2002fe045ee7bb0b3d98f1a47f8b2bc851dcd1c74332919
 
 case $TARGET in
   x86_64-*-linux-*)


### PR DESCRIPTION
This upgrades OpenSSL to 1.0.2h on Unix and *1.0.2g* on Windows/MSVC. The place we get our Windows builds has not yet upgraded to 'h'.