### PR TITLE
Point PATH to toolchain/bin on Windows

### DIFF
--- a/src/rustup/env_var.rs
+++ b/src/rustup/env_var.rs
@@ -1,9 +1,23 @@
 use std::ffi::OsString;
 use std::env;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
-pub fn set_path(name: &str, value: &Path, cmd: &mut Command) {
+pub fn append_path(name: &str, value: Vec<PathBuf>, cmd: &mut Command) {
+    let old_value = env::var_os(name);
+    let mut parts: Vec<PathBuf>;
+    if let Some(ref v) = old_value {
+        parts = env::split_paths(v).collect();
+        parts.extend(value);
+    } else {
+        parts = value;
+    }
+    if let Ok(new_value) = env::join_paths(parts) {
+        cmd.env(name, new_value);
+    }
+}
+
+pub fn prepend_path(name: &str, value: &Path, cmd: &mut Command) {
     let old_value = env::var_os(name);
     let mut parts = vec![value.to_owned()];
     if let Some(ref v) = old_value {

--- a/src/rustup/toolchain.rs
+++ b/src/rustup/toolchain.rs
@@ -307,8 +307,16 @@ impl<'a> Toolchain<'a> {
     pub fn set_ldpath(&self, cmd: &mut Command) {
         let new_path = self.path.join("lib");
 
-        env_var::set_path("LD_LIBRARY_PATH", &new_path, cmd);
-        env_var::set_path("DYLD_LIBRARY_PATH", &new_path, cmd);
+        env_var::prepend_path("LD_LIBRARY_PATH", &new_path, cmd);
+        env_var::prepend_path("DYLD_LIBRARY_PATH", &new_path, cmd);
+
+        // Append first cargo_home, then toolchain/bin to the PATH
+        let mut path_to_append = Vec::with_capacity(2);
+        if let Ok(cargo_home) = utils::cargo_home() {
+            path_to_append.push(cargo_home.join("bin"));
+        }
+        path_to_append.push(self.path.join("bin"));
+        env_var::append_path("PATH", path_to_append, cmd);
     }
 
     pub fn doc_path(&self, relative: &str) -> Result<PathBuf> {


### PR DESCRIPTION
Yes, this again. On Windows, LD_LIBRARY_PATH and DYLD_LIBRARY_PATH are not obeyed, and .dlls are searched for in the PATH (and located in the bin directory).

This becomes relevant when attempting to link to a `rustc_private` crate such as libsyntax.

Prior art: https://github.com/brson/multirust/pull/99