### PR TITLE
Expand `rustup show`

### DIFF
--- a/src/rustup-cli/common.rs
+++ b/src/rustup-cli/common.rs
@@ -295,8 +295,6 @@ pub fn list_targets(toolchain: &Toolchain) -> Result<()> {
 pub fn list_toolchains(cfg: &Cfg) -> Result<()> {
     let mut toolchains = try!(cfg.list_toolchains());
 
-    toolchains.sort();
-
     if toolchains.is_empty() {
         println!("no installed toolchains");
     } else {

--- a/src/rustup-cli/common.rs
+++ b/src/rustup-cli/common.rs
@@ -212,7 +212,7 @@ pub fn update_all_channels(cfg: &Cfg, self_update: bool) -> Result<()> {
     Ok(())
 }
 
-fn rustc_version(toolchain: &Toolchain) -> String {
+pub fn rustc_version(toolchain: &Toolchain) -> String {
     if toolchain.exists() {
         let rustc_path = toolchain.binary_file("rustc");
         if utils::is_file(&rustc_path) {
@@ -293,7 +293,7 @@ pub fn list_targets(toolchain: &Toolchain) -> Result<()> {
 }
 
 pub fn list_toolchains(cfg: &Cfg) -> Result<()> {
-    let mut toolchains = try!(cfg.list_toolchains());
+    let toolchains = try!(cfg.list_toolchains());
 
     if toolchains.is_empty() {
         println!("no installed toolchains");

--- a/src/rustup-utils/src/utils.rs
+++ b/src/rustup-utils/src/utils.rs
@@ -492,7 +492,7 @@ pub fn string_from_winreg_value(val: &winreg::RegValue) -> Option<String> {
 }
 
 pub fn toolchain_sort<T: AsRef<str>>(v: &mut Vec<T>) {
-    fn channel_sort_key(s: &str) -> String {
+    fn toolchain_sort_key(s: &str) -> String {
         if s.starts_with("stable") {
             format!("0{}", s)
         } else if s.starts_with("beta") {
@@ -507,8 +507,8 @@ pub fn toolchain_sort<T: AsRef<str>>(v: &mut Vec<T>) {
     v.sort_by(|a, b| {
         let a_str: &str = a.as_ref();
         let b_str: &str = b.as_ref();
-        let a_key = channel_sort_key(a_str);
-        let b_key = channel_sort_key(b_str);
+        let a_key = toolchain_sort_key(a_str);
+        let b_key = toolchain_sort_key(b_str);
         a_key.cmp(&b_key)
     });
 }

--- a/src/rustup-utils/src/utils.rs
+++ b/src/rustup-utils/src/utils.rs
@@ -14,6 +14,7 @@ use raw;
 use winapi::DWORD;
 #[cfg(windows)]
 use winreg;
+use std::cmp::Ord;
 
 pub use raw::{is_directory, is_file, path_exists, if_not_empty, random_string, prefix_arg,
                     has_cmd, find_cmd};
@@ -488,4 +489,26 @@ pub fn string_from_winreg_value(val: &winreg::RegValue) -> Option<String> {
         }
         _ => None
     }
+}
+
+pub fn toolchain_sort<T: AsRef<str>>(v: &mut Vec<T>) {
+    fn channel_sort_key(s: &str) -> String {
+        if s.starts_with("stable") {
+            format!("0{}", s)
+        } else if s.starts_with("beta") {
+            format!("1{}", s)
+        } else if s.starts_with("nightly") {
+            format!("2{}", s)
+        } else {
+            format!("3{}", s)
+        }
+    }
+
+    v.sort_by(|a, b| {
+        let a_str: &str = a.as_ref();
+        let b_str: &str = b.as_ref();
+        let a_key = channel_sort_key(a_str);
+        let b_key = channel_sort_key(b_str);
+        a_key.cmp(&b_key)
+    });
 }

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -310,6 +310,9 @@ r"");
 
 #[test]
 fn show_multiple_targets() {
+    // Using the MULTI_ARCH1 target doesn't work on i686 linux
+    if cfg!(target_os = "linux") && cfg!(target_arch = "x86") { return }
+
     clitools::setup(Scenario::MultiHost, &|config| {
         expect_ok(config, &["rustup", "default",
                             &format!("nightly-{}", clitools::MULTI_ARCH1)]);
@@ -334,6 +337,8 @@ r"");
 
 #[test]
 fn show_multiple_toolchains_and_targets() {
+    if cfg!(target_os = "linux") && cfg!(target_arch = "x86") { return }
+
     clitools::setup(Scenario::MultiHost, &|config| {
         expect_ok(config, &["rustup", "default",
                             &format!("nightly-{}", clitools::MULTI_ARCH1)]);


### PR DESCRIPTION
Now it shows the active toolchain, the installed targets for the
active toolchain, and the installed toolchains. When there are
no additional toolchains or targets, the category headers
for them are not displayed.