### PR TITLE
Refuse to install if it looks like other Rust installations are present

### DIFF
--- a/tests/cli-self-update.rs
+++ b/tests/cli-self-update.rs
@@ -1046,3 +1046,25 @@ fn uninstall_doesnt_mess_with_a_non_unicode_path() {
         assert!(path.bytes == reg_value.bytes);
     });
 }
+
+#[test]
+#[ignore] // untestable
+fn install_but_multirust_is_installed() {
+}
+
+#[test]
+#[ignore] // untestable
+fn install_but_rustc_is_installed() {
+}
+
+#[test]
+fn install_but_rustup_sh_is_installed() {
+    setup(&|config| {
+        let rustup_dir = config.homedir.join(".rustup");
+        fs::create_dir_all(&rustup_dir).unwrap();
+        let version_file = rustup_dir.join("rustup-version");
+        raw::write_file(&version_file, "").unwrap();
+        expect_err(config, &["rustup-init", "-y"],
+                   "cannot install while rustup.sh is installed");
+    });
+}


### PR DESCRIPTION
Detects multirust.sh, rustc tarballs, and rustup.sh. There's a
test case for rustup.sh. The others I've done manually.

Fixes https://github.com/rust-lang-nursery/rustup.rs/issues/349