### PR TITLE
Version bumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.10
+
+* [Fix URLs to docs](https://github.com/rust-lang-nursery/rustup.rs/pull/414).
+
 # 0.1.9
 
 * [Do TLS hostname verification](https://github.com/rust-lang-nursery/rustup.rs/pull/400).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,9 +1,9 @@
 [root]
 name = "rustup"
-version = "0.1.10"
+version = "0.1.11-pre"
 dependencies = [
  "clap 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "error-chain 0.1.10",
+ "error-chain 0.1.11-pre",
  "itertools 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -11,9 +11,9 @@ dependencies = [
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.69 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustup-dist 0.1.10",
- "rustup-mock 0.1.10",
- "rustup-utils 0.1.10",
+ "rustup-dist 0.1.11-pre",
+ "rustup-mock 0.1.11-pre",
+ "rustup-utils 0.1.11-pre",
  "scopeguard 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -152,7 +152,7 @@ dependencies = [
 
 [[package]]
 name = "error-chain"
-version = "0.1.10"
+version = "0.1.11-pre"
 dependencies = [
  "backtrace 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -449,15 +449,15 @@ dependencies = [
 
 [[package]]
 name = "rustup-dist"
-version = "0.1.10"
+version = "0.1.11-pre"
 dependencies = [
- "error-chain 0.1.10",
+ "error-chain 0.1.11-pre",
  "flate2 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "ole32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.69 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustup-mock 0.1.10",
- "rustup-utils 0.1.10",
+ "rustup-mock 0.1.11-pre",
+ "rustup-utils 0.1.11-pre",
  "sha2 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tar 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -468,12 +468,12 @@ dependencies = [
 
 [[package]]
 name = "rustup-mock"
-version = "0.1.10"
+version = "0.1.11-pre"
 dependencies = [
  "flate2 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustup-utils 0.1.10",
+ "rustup-utils 0.1.11-pre",
  "scopeguard 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tar 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -487,10 +487,10 @@ dependencies = [
 
 [[package]]
 name = "rustup-utils"
-version = "0.1.10"
+version = "0.1.11-pre"
 dependencies = [
  "advapi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "error-chain 0.1.10",
+ "error-chain 0.1.11-pre",
  "hyper 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,9 +1,9 @@
 [root]
 name = "rustup"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "clap 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "error-chain 0.1.9",
+ "error-chain 0.1.10",
  "itertools 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -11,9 +11,9 @@ dependencies = [
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.69 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustup-dist 0.1.9",
- "rustup-mock 0.1.9",
- "rustup-utils 0.1.9",
+ "rustup-dist 0.1.10",
+ "rustup-mock 0.1.10",
+ "rustup-utils 0.1.10",
  "scopeguard 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -152,7 +152,7 @@ dependencies = [
 
 [[package]]
 name = "error-chain"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "backtrace 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -167,7 +167,7 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -328,10 +328,10 @@ dependencies = [
 [[package]]
 name = "native-tls"
 version = "0.1.0"
-source = "git+https://github.com/sfackler/rust-native-tls.git#2bd06d4686a31d46f83f243a6b10650ac013ffa0"
+source = "git+https://github.com/sfackler/rust-native-tls.git#a3d03b6ab5cee02313ff79a9e96a10b0c9b9e28a"
 dependencies = [
  "openssl 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-verify 0.1.0 (git+https://github.com/sfackler/rust-openssl-verify)",
+ "openssl-verify 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "schannel 0.0.2 (git+https://github.com/sfackler/schannel-rs)",
  "security-framework 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -391,7 +391,7 @@ dependencies = [
 [[package]]
 name = "openssl-verify"
 version = "0.1.0"
-source = "git+https://github.com/sfackler/rust-openssl-verify#6fd9fd9209749361079e627eab69d2edb8cb3dec"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "openssl 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -449,15 +449,15 @@ dependencies = [
 
 [[package]]
 name = "rustup-dist"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
- "error-chain 0.1.9",
- "flate2 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.1.10",
+ "flate2 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "ole32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.69 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustup-mock 0.1.9",
- "rustup-utils 0.1.9",
+ "rustup-mock 0.1.10",
+ "rustup-utils 0.1.10",
  "sha2 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tar 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -468,12 +468,12 @@ dependencies = [
 
 [[package]]
 name = "rustup-mock"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
- "flate2 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustup-utils 0.1.9",
+ "rustup-utils 0.1.10",
  "scopeguard 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tar 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -487,10 +487,10 @@ dependencies = [
 
 [[package]]
 name = "rustup-utils"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "advapi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "error-chain 0.1.9",
+ "error-chain 0.1.10",
  "hyper 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "rustup"
-version = "0.1.10"
+version = "0.1.11-pre"
 authors = [ "Diggory Blake <diggsey@googlemail.com>" ]
 description = "multirust in rust - manage multiple rust installations with ease"
 
@@ -18,9 +18,9 @@ license = "MIT OR Apache-2.0"
 build = "build.rs"
 
 [dependencies]
-rustup-dist = { path = "src/rustup-dist", version = "0.1.10" }
-rustup-utils = { path = "src/rustup-utils", version = "0.1.10" }
-error-chain = { path = "src/error-chain", version = "0.1.10" }
+rustup-dist = { path = "src/rustup-dist", version = "0.1.11-pre" }
+rustup-utils = { path = "src/rustup-utils", version = "0.1.11-pre" }
+error-chain = { path = "src/error-chain", version = "0.1.11-pre" }
 clap = "2.2.4"
 regex = "0.1.41"
 url = "1.1.0"
@@ -41,7 +41,7 @@ user32-sys = "0.1.2"
 kernel32-sys = "0.2.1"
 
 [dev-dependencies]
-rustup-mock = { path = "src/rustup-mock", version = "0.1.10" }
+rustup-mock = { path = "src/rustup-mock", version = "0.1.11-pre" }
 lazy_static = "0.1.15"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "rustup"
-version = "0.1.9"
+version = "0.1.10"
 authors = [ "Diggory Blake <diggsey@googlemail.com>" ]
 description = "multirust in rust - manage multiple rust installations with ease"
 
@@ -18,9 +18,9 @@ license = "MIT OR Apache-2.0"
 build = "build.rs"
 
 [dependencies]
-rustup-dist = { path = "src/rustup-dist", version = "0.1.9" }
-rustup-utils = { path = "src/rustup-utils", version = "0.1.9" }
-error-chain = { path = "src/error-chain", version = "0.1.9" }
+rustup-dist = { path = "src/rustup-dist", version = "0.1.10" }
+rustup-utils = { path = "src/rustup-utils", version = "0.1.10" }
+error-chain = { path = "src/error-chain", version = "0.1.10" }
 clap = "2.2.4"
 regex = "0.1.41"
 url = "1.1.0"
@@ -41,7 +41,7 @@ user32-sys = "0.1.2"
 kernel32-sys = "0.2.1"
 
 [dev-dependencies]
-rustup-mock = { path = "src/rustup-mock", version = "0.1.9" }
+rustup-mock = { path = "src/rustup-mock", version = "0.1.10" }
 lazy_static = "0.1.15"
 
 [lib]

--- a/src/error-chain/Cargo.toml
+++ b/src/error-chain/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "error-chain"
-version = "0.1.10"
+version = "0.1.11-pre"
 authors = [ "Brian Anderson <banderson@mozilla.com>",
             "Paul Colomiets <paul@colomiets.name>",
             "Colin Kiegel <kiegel@gmx.de>"]

--- a/src/error-chain/Cargo.toml
+++ b/src/error-chain/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "error-chain"
-version = "0.1.9"
+version = "0.1.10"
 authors = [ "Brian Anderson <banderson@mozilla.com>",
             "Paul Colomiets <paul@colomiets.name>",
             "Colin Kiegel <kiegel@gmx.de>"]

--- a/src/rustup-dist/Cargo.toml
+++ b/src/rustup-dist/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "rustup-dist"
-version = "0.1.10"
+version = "0.1.11-pre"
 authors = [ "Diggory Blake <diggsey@googlemail.com>" ]
 description = "Installation from a Rust distribution server"
 build = "build.rs"
@@ -23,9 +23,9 @@ tempdir = "0.3.4"
 walkdir = "0.1.5"
 toml = "0.1.27"
 sha2 = "0.1.2"
-rustup-utils = { path = "../rustup-utils", version = "0.1.10" }
-error-chain = { path = "../error-chain", version = "0.1.10" }
-rustup-mock = { path = "../rustup-mock", version = "0.1.10" }
+rustup-utils = { path = "../rustup-utils", version = "0.1.11-pre" }
+error-chain = { path = "../error-chain", version = "0.1.11-pre" }
+rustup-mock = { path = "../rustup-mock", version = "0.1.11-pre" }
 
 [lib]
 name = "rustup_dist"

--- a/src/rustup-dist/Cargo.toml
+++ b/src/rustup-dist/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "rustup-dist"
-version = "0.1.9"
+version = "0.1.10"
 authors = [ "Diggory Blake <diggsey@googlemail.com>" ]
 description = "Installation from a Rust distribution server"
 build = "build.rs"
@@ -23,9 +23,9 @@ tempdir = "0.3.4"
 walkdir = "0.1.5"
 toml = "0.1.27"
 sha2 = "0.1.2"
-rustup-utils = { path = "../rustup-utils", version = "0.1.9" }
-error-chain = { path = "../error-chain", version = "0.1.9" }
-rustup-mock = { path = "../rustup-mock", version = "0.1.9" }
+rustup-utils = { path = "../rustup-utils", version = "0.1.10" }
+error-chain = { path = "../error-chain", version = "0.1.10" }
+rustup-mock = { path = "../rustup-mock", version = "0.1.10" }
 
 [lib]
 name = "rustup_dist"

--- a/src/rustup-mock/Cargo.toml
+++ b/src/rustup-mock/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "rustup-mock"
-version = "0.1.9"
+version = "0.1.10"
 authors = [ "Diggory Blake <diggsey@googlemail.com>" ]
 description = "Test mocks for multirust"
 
@@ -19,7 +19,7 @@ tempdir = "0.3.4"
 itertools = "0.4.1"
 tar = "0.4.0"
 toml = "0.1.27"
-rustup-utils = { path = "../rustup-utils", version = "0.1.9" }
+rustup-utils = { path = "../rustup-utils", version = "0.1.10" }
 sha2 = "0.1.2"
 
 [target."cfg(windows)".dependencies]

--- a/src/rustup-mock/Cargo.toml
+++ b/src/rustup-mock/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "rustup-mock"
-version = "0.1.10"
+version = "0.1.11-pre"
 authors = [ "Diggory Blake <diggsey@googlemail.com>" ]
 description = "Test mocks for multirust"
 
@@ -19,7 +19,7 @@ tempdir = "0.3.4"
 itertools = "0.4.1"
 tar = "0.4.0"
 toml = "0.1.27"
-rustup-utils = { path = "../rustup-utils", version = "0.1.10" }
+rustup-utils = { path = "../rustup-utils", version = "0.1.11-pre" }
 sha2 = "0.1.2"
 
 [target."cfg(windows)".dependencies]

--- a/src/rustup-utils/Cargo.toml
+++ b/src/rustup-utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "rustup-utils"
-version = "0.1.9"
+version = "0.1.10"
 authors = [ "Diggory Blake <diggsey@googlemail.com>" ]
 description = "multirust in rust - manage multiple rust installations with ease"
 
@@ -14,7 +14,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 rand = "0.3.11"
 scopeguard = "0.1.2"
-error-chain = { path = "../error-chain", version = "0.1.9" }
+error-chain = { path = "../error-chain", version = "0.1.10" }
 libc = "0.2.0"
 native-tls = { git = "https://github.com/sfackler/rust-native-tls.git" }
 rustc-serialize = "0.3.19"

--- a/src/rustup-utils/Cargo.toml
+++ b/src/rustup-utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "rustup-utils"
-version = "0.1.10"
+version = "0.1.11-pre"
 authors = [ "Diggory Blake <diggsey@googlemail.com>" ]
 description = "multirust in rust - manage multiple rust installations with ease"
 
@@ -14,7 +14,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 rand = "0.3.11"
 scopeguard = "0.1.2"
-error-chain = { path = "../error-chain", version = "0.1.10" }
+error-chain = { path = "../error-chain", version = "0.1.11-pre" }
 libc = "0.2.0"
 native-tls = { git = "https://github.com/sfackler/rust-native-tls.git" }
 rustc-serialize = "0.3.19"


### PR DESCRIPTION
Prepare the 0.1.10 release, which contains only a single fix to the URLs in the Cargo files. Then bump all crates to 0.1.11-pre.