### PR TITLE
Improvements to welcome screen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,6 +8,7 @@ dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "markdown 0.1.2 (git+https://github.com/Diggsey/markdown.rs.git)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.69 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -296,6 +297,15 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "markdown"
+version = "0.1.2"
+source = "git+https://github.com/Diggsey/markdown.rs.git#d56d7cad4fe4937913cb83fe7e3990bf2364b917"
+dependencies = [
+ "pipeline 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.69 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -395,6 +405,11 @@ source = "git+https://github.com/sfackler/rust-openssl-verify#6fd9fd920974936107
 dependencies = [
  "openssl 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "pipeline"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "pkg-config"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ rand = "0.3.11"
 scopeguard = "0.1.2"
 rustc-serialize = "0.3"
 sha2 = "0.1.2"
+markdown = { git="https://github.com/Diggsey/markdown.rs.git" }
 
 [target."cfg(windows)".dependencies]
 winapi = "0.2.4"

--- a/src/rustup-cli/common.rs
+++ b/src/rustup-cli/common.rs
@@ -34,15 +34,18 @@ pub enum Confirm {
     Yes, No, Advanced
 }
 
-pub fn confirm_advanced(default: Confirm) -> Result<Confirm> {
+pub fn confirm_advanced() -> Result<Confirm> {
+    println!("");
+    println!("1) Proceed with installation (default)");
+    println!("2) Customize installation");
+    println!("3) Cancel installation");
+
     let _ = std::io::stdout().flush();
     let input = try!(read_line());
 
     let r = match &*input {
-        "y" | "Y" | "yes" => Confirm::Yes,
-        "n" | "N" | "no" => Confirm::No,
-        "a" | "A" | "advanced" => Confirm::Advanced,
-        "" => default,
+        "1"|"" => Confirm::Yes,
+        "2" => Confirm::Advanced,
         _ => Confirm::No,
     };
 
@@ -99,7 +102,7 @@ pub fn set_globals(verbose: bool) -> Result<Cfg> {
 
     let download_tracker = RefCell::new(DownloadTracker::new());
 
-    Ok(try!(Cfg::from_env(shared_ntfy!(move |n: Notification| { 
+    Ok(try!(Cfg::from_env(shared_ntfy!(move |n: Notification| {
        if download_tracker.borrow_mut().handle_notification(&n) {
             return;
         }
@@ -302,10 +305,10 @@ pub fn list_toolchains(cfg: &Cfg) -> Result<()> {
     } else {
         if let Ok(Some(def_toolchain)) = cfg.find_default() {
             for toolchain in toolchains {
-                let if_default = if def_toolchain.name() == &*toolchain { 
-                    " (default)" 
-                } else { 
-                    "" 
+                let if_default = if def_toolchain.name() == &*toolchain {
+                    " (default)"
+                } else {
+                    ""
                 };
                 println!("{}{}", &toolchain, if_default);
             }
@@ -328,9 +331,9 @@ pub fn list_overrides(cfg: &Cfg) -> Result<()> {
         println!("no overrides");
     } else {
         for o in overrides {
-            split_override::<String>(&o, ';').map(|li| 
-                println!("{:<40}\t{:<20}", 
-                         utils::format_path_for_display(&li.0), 
+            split_override::<String>(&o, ';').map(|li|
+                println!("{:<40}\t{:<20}",
+                         utils::format_path_for_display(&li.0),
                          li.1)
             );
         }

--- a/src/rustup-cli/main.rs
+++ b/src/rustup-cli/main.rs
@@ -18,6 +18,7 @@ extern crate rand;
 extern crate scopeguard;
 extern crate tempdir;
 extern crate sha2;
+extern crate markdown;
 
 #[cfg(windows)]
 extern crate winapi;
@@ -169,4 +170,3 @@ fn fix_windows_reg_key() {
 
 #[cfg(not(windows))]
 fn fix_windows_reg_key() { }
-

--- a/src/rustup-cli/self_update.rs
+++ b/src/rustup-cli/self_update.rs
@@ -160,7 +160,7 @@ r"# Thanks for hacking in Rust!
 This will uninstall all Rust toolchains and data, and remove
 `{cargo_home}/bin` from your `PATH` environment variable.
 
-Continue? (y/N)"
+"
     }
 }
 
@@ -254,23 +254,24 @@ pub fn install(no_prompt: bool, verbose: bool,
 
     // More helpful advice, skip if -y
     if !no_prompt {
-        if !opts.no_modify_path {
+        let msg = if !opts.no_modify_path {
             if cfg!(unix) {
                 let cargo_home = try!(canonical_cargo_home());
-                println!(post_install_msg_unix!(),
-                         cargo_home = cargo_home);
+                format!(post_install_msg_unix!(),
+                         cargo_home = cargo_home)
             } else {
-                println!(post_install_msg_win!());
+                format!(post_install_msg_win!())
             }
         } else {
             if cfg!(unix) {
                 let cargo_home = try!(canonical_cargo_home());
-                println!(post_install_msg_unix_no_modify_path!(),
-                         cargo_home = cargo_home);
+                format!(post_install_msg_unix_no_modify_path!(),
+                         cargo_home = cargo_home)
             } else {
-                println!(post_install_msg_win_no_modify_path!());
+                format!(post_install_msg_win_no_modify_path!())
             }
-        }
+        };
+        term2::stdout().md(msg);
 
         // On windows, where installation happens in a console
         // that may have opened just for this purpose, require
@@ -476,7 +477,8 @@ pub fn uninstall(no_prompt: bool) -> Result<()> {
         println!("");
         let ref msg = format!(pre_uninstall_msg!(),
                               cargo_home = try!(canonical_cargo_home()));
-        if !try!(common::confirm(msg, false)) {
+        term2::stdout().md(msg);
+        if !try!(common::confirm("\nContinue? (y/N)", false)) {
             info!("aborting uninstallation");
             return Ok(());
         }

--- a/src/rustup-cli/self_update.rs
+++ b/src/rustup-cli/self_update.rs
@@ -87,7 +87,7 @@ pre_install_msg_template!(
 "This path will then be added to your `PATH` environment variable by
 modifying the profile file located at:
 
-{rcfiles}"
+    {rcfiles}"
     )};
 }
 

--- a/src/rustup-cli/self_update.rs
+++ b/src/rustup-cli/self_update.rs
@@ -44,6 +44,7 @@ use std::process::{self, Command};
 use std::fs::{self, File};
 use std::io::Read;
 use tempdir::TempDir;
+use term2;
 
 pub struct InstallOpts {
     pub default_toolchain: String,
@@ -57,7 +58,7 @@ macro_rules! pre_install_msg_template {
     ($platform_msg: expr) => {
 concat!(
 r"
-Welcome to Rust!
+# Welcome to Rust!
 
 This will download and install the official compiler for the Rust
 programming language, and its package manager, Cargo.
@@ -65,7 +66,7 @@ programming language, and its package manager, Cargo.
 It will add the `cargo`, `rustc`, `rustup` and other commands to
 Cargo's bin directory, located at:
 
-{cargo_home_bin}
+    {cargo_home_bin}
 
 ",
 $platform_msg
@@ -75,12 +76,8 @@ r#"
 You can uninstall at any time with `rustup self uninstall` and
 these changes will be reverted.
 
-WARNING: This is beta software.
-
-To cancel installation, type "n", or for more options type "a",
-then press the Enter key to continue.
-
-Press the Enter key to install Rust."#
+*WARNING*: This is beta software.
+"#
     )};
 }
 
@@ -98,21 +95,21 @@ macro_rules! pre_install_msg_win {
     () => {
 pre_install_msg_template!(
 "This path will then be added to your `PATH` environment variable by
-modifying the HKEY_CURRENT_USER/Environment/PATH registry key."
+modifying the `HKEY_CURRENT_USER/Environment/PATH` registry key."
     )};
 }
 
 macro_rules! pre_install_msg_no_modify_path {
     () => {
 pre_install_msg_template!(
-"This path needs to be in your PATH environment variable,
+"This path needs to be in your `PATH` environment variable,
 but will not be added automatically."
     )};
 }
 
 macro_rules! post_install_msg_unix {
     () => {
-r"Rust is installed now. Great!
+r"# Rust is installed now. Great!
 
 To get started you need Cargo's bin directory in your `PATH`
 environment variable. Next time you log in this will be done
@@ -125,7 +122,7 @@ To configure your current shell run `source {cargo_home}/env`.
 
 macro_rules! post_install_msg_win {
     () => {
-r"Rust is installed now. Great!
+r"# Rust is installed now. Great!
 
 To get started you need Cargo's bin directory in your `PATH`
 environment variable. Future applications will automatically have the
@@ -136,7 +133,7 @@ correct environment, but you may need to restart your current shell.
 
 macro_rules! post_install_msg_unix_no_modify_path {
     () => {
-r"Rust is installed now. Great!
+r"# Rust is installed now. Great!
 
 To get started you need Cargo's bin directory in your `PATH`
 environment variable.
@@ -148,7 +145,7 @@ To configure your current shell run `source {cargo_home}/env`.
 
 macro_rules! post_install_msg_win_no_modify_path {
     () => {
-r"Rust is installed now. Great!
+r"# Rust is installed now. Great!
 
 To get started you need Cargo's bin directory in your `PATH`
 environment variable. This has not been done automatically.
@@ -158,7 +155,7 @@ environment variable. This has not been done automatically.
 
 macro_rules! pre_uninstall_msg {
     () => {
-r"Thanks for hacking in Rust!
+r"# Thanks for hacking in Rust!
 
 This will uninstall all Rust toolchains and data, and remove
 `{cargo_home}/bin` from your `PATH` environment variable.
@@ -191,43 +188,39 @@ fn canonical_cargo_home() -> Result<String> {
 /// CARGO_HOME/bin, hardlinking the various Rust tools to it,
 /// and and adding CARGO_HOME/bin to PATH.
 pub fn install(no_prompt: bool, verbose: bool,
-               opts: InstallOpts) -> Result<()> {
+               mut opts: InstallOpts) -> Result<()> {
 
     try!(do_pre_install_sanity_checks());
 
-    let selected_opts;
-
     if !no_prompt {
         let ref msg = try!(pre_install_msg(opts.no_modify_path));
-        println!("{}", msg);
-        match try!(common::confirm_advanced(Confirm::Yes)) {
-            Confirm::No => {
-                info!("aborting installation");
-                return Ok(());
-            }
-            Confirm::Yes => {
-                selected_opts = opts;
-            }
-            Confirm::Advanced => {
-                if let Some(opts) = try!(advanced_install(opts)) {
-                    selected_opts = opts;
-                } else {
+
+        term2::stdout().md(msg);
+
+        loop {
+            term2::stdout().md(current_install_opts(&opts));
+            match try!(common::confirm_advanced()) {
+                Confirm::No => {
                     info!("aborting installation");
                     return Ok(());
+                },
+                Confirm::Yes => {
+                    break;
+                },
+                Confirm::Advanced => {
+                    opts = try!(customize_install(opts));
                 }
             }
         }
-    } else {
-        selected_opts = opts;
     }
 
     let install_res: Result<()> = (|| {
         try!(cleanup_legacy());
         try!(install_bins());
-        if !selected_opts.no_modify_path {
+        if !opts.no_modify_path {
             try!(do_add_to_path(&get_add_path_methods()));
         }
-        try!(maybe_install_rust(&selected_opts.default_toolchain, verbose));
+        try!(maybe_install_rust(&opts.default_toolchain, verbose));
 
         if cfg!(unix) {
             let ref env_file = try!(utils::cargo_home()).join("env");
@@ -261,7 +254,7 @@ pub fn install(no_prompt: bool, verbose: bool,
 
     // More helpful advice, skip if -y
     if !no_prompt {
-        if !selected_opts.no_modify_path {
+        if !opts.no_modify_path {
             if cfg!(unix) {
                 let cargo_home = try!(canonical_cargo_home());
                 println!(post_install_msg_unix!(),
@@ -364,63 +357,36 @@ fn pre_install_msg(no_modify_path: bool) -> Result<String> {
     }
 }
 
-// Interactive editing of the install options
-fn advanced_install(mut opts: InstallOpts) -> Result<Option<InstallOpts>> {
+fn current_install_opts(opts: &InstallOpts) -> String {
+    format!(
+        r"Current installation options:
 
-    fn print_opts(opts: &InstallOpts) {
-        println!(
-            r"Selected installation options:
-
-     default toolchain: {}
-  modify PATH variable: {}
+- `   `default toolchain: `{}`
+- modify PATH variable: `{}`
 ",
-            opts.default_toolchain,
-            if !opts.no_modify_path { "yes" } else { "no" }
-            );
-    }
+        opts.default_toolchain,
+        if !opts.no_modify_path { "yes" } else { "no" }
+    )
+}
 
-    loop {
+// Interactive editing of the install options
+fn customize_install(mut opts: InstallOpts) -> Result<InstallOpts> {
 
-        print_opts(&opts);
+    println!(
+        "I'm going to ask you the value of each these installation options.\n\
+         You may simply press the Enter key to leave unchanged.");
 
-        println!(
-            "I'm going to ask you the value of each these installation options.\n\
-             You may simply press the Enter key to accept the default.");
+    println!("");
 
-        println!("");
+    opts.default_toolchain = try!(common::question_str(
+        "Default toolchain? (stable/beta/nightly)",
+        &opts.default_toolchain));
 
-        opts.default_toolchain = try!(common::question_str(
-            "Default toolchain? (stable/beta/nightly)",
-            &opts.default_toolchain));
+    opts.no_modify_path = !try!(common::question_bool(
+        "Modify PATH variable? (y/n)",
+        !opts.no_modify_path));
 
-        opts.no_modify_path = !try!(common::question_bool(
-            "Modify PATH variable? (y/n)",
-            !opts.no_modify_path));
-
-        println!("That's it! We're ready to install Rust.");
-        println!("");
-
-        print_opts(&opts);
-
-        println!(
-r#"To cancel installation, type "n", or for more options type "a",
-then press the Enter key to continue.
-
-Press the Enter key to install Rust. "#);
-
-        match try!(common::confirm_advanced(Confirm::Yes)) {
-            Confirm::No => {
-                info!("aborting installation");
-                return Ok(None);
-            }
-            Confirm::Yes => {
-                return Ok(Some(opts));
-            }
-            Confirm::Advanced => {
-                continue;
-            }
-        }
-    }
+    Ok(opts)
 }
 
 // Before multirust-rs installed bins to $CARGO_HOME/bin it installed

--- a/src/rustup-cli/term2.rs
+++ b/src/rustup-cli/term2.rs
@@ -5,27 +5,208 @@
 use std::io;
 use term;
 use rustup_utils::tty;
+use markdown::parser::{Block, Span, ListItem};
+use markdown::tokenize;
 
 pub use term::color;
 pub use term::Attr;
 
+pub trait Instantiable {
+    fn instance() -> Self;
+}
+
+impl Instantiable for io::Stdout {
+    fn instance() -> Self { io::stdout() }
+}
+
+impl Instantiable for io::Stderr {
+    fn instance() -> Self { io::stderr() }
+}
+
+pub struct Terminal<T: Instantiable + io::Write>(Option<Box<term::Terminal<Output = T> + Send>>);
+pub type StdoutTerminal = Terminal<io::Stdout>;
+pub type StderrTerminal = Terminal<io::Stderr>;
+
 pub fn stdout() -> StdoutTerminal {
-    StdoutTerminal(term::stdout())
+    Terminal(term::stdout())
 }
 
 pub fn stderr() -> StderrTerminal {
-    StderrTerminal(term::stderr())
+    Terminal(term::stderr())
 }
 
-pub struct StdoutTerminal(Option<Box<term::StdoutTerminal>>);
-pub struct StderrTerminal(Option<Box<term::StderrTerminal>>);
+// Handles the wrapping of text written to the console
+struct LineWrapper<'a, T: io::Write + 'a> {
+    indent: u32,
+    margin: u32,
+    pos: u32,
+    pub w: &'a mut T
+}
 
-impl io::Write for StdoutTerminal {
+impl<'a, T: io::Write + 'a> LineWrapper<'a, T> {
+    // Just write a newline
+    fn write_line(&mut self) {
+        let _ = writeln!(self.w, "");
+        // Reset column position to start of line
+        self.pos = 0;
+    }
+    // Called before writing text to ensure indent is applied
+    fn write_indent(&mut self) {
+        if self.pos == 0 {
+            // Write a space for each level of indent
+            for _ in 0..self.indent {
+                let _ = write!(self.w, " ");
+            }
+            self.pos = self.indent;
+        }
+    }
+    // Write a non-breaking word
+    fn write_word(&mut self, word: &str) {
+        // Ensure correct indentation
+        self.write_indent();
+        let word_len = word.len() as u32;
+
+        // If this word goes past the margin
+        if self.pos + word_len > self.margin {
+            // And adding a newline would give us more space
+            if self.pos > self.indent {
+                // Then add a newline!
+                self.write_line();
+                self.write_indent();
+            }
+        }
+
+        // Write the word
+        let _ = write!(self.w, "{}", word);
+        self.pos += word_len;
+    }
+    fn write_space(&mut self) {
+        if self.pos > self.indent {
+            self.write_word(" ");
+        }
+    }
+    // Writes a span of text which wraps at the margin
+    fn write_span(&mut self, text: &str) {
+        // Allow words to wrap on whitespace
+        let mut is_first = true;
+        for word in text.split(char::is_whitespace) {
+            if is_first {
+                is_first = false;
+            } else {
+                self.write_space();
+            }
+            self.write_word(word);
+        }
+    }
+    // Constructor
+    fn new(w: &'a mut T, indent: u32, margin: u32) -> Self {
+        LineWrapper {
+            indent: indent,
+            margin: margin,
+            pos: indent,
+            w: w
+        }
+    }
+}
+
+// Handles the formatting of text
+struct LineFormatter<'a, T: Instantiable + io::Write + 'a> {
+    wrapper: LineWrapper<'a, Terminal<T>>,
+    attrs: Vec<Attr>
+}
+
+impl<'a, T: Instantiable + io::Write + 'a> LineFormatter<'a, T> {
+    fn new(w: &'a mut Terminal<T>, indent: u32, margin: u32) -> Self {
+        LineFormatter {
+            wrapper: LineWrapper::new(w, indent, margin),
+            attrs: Vec::new()
+        }
+    }
+    fn push_attr(&mut self, attr: Attr) {
+        self.attrs.push(attr);
+        let _ = self.wrapper.w.attr(attr);
+    }
+    fn pop_attr(&mut self) {
+        self.attrs.pop();
+        let _ = self.wrapper.w.reset();
+        for attr in &self.attrs {
+            let _ = self.wrapper.w.attr(*attr);
+        }
+    }
+    fn do_spans(&mut self, spans: Vec<Span>) {
+        for span in spans {
+            match span {
+                Span::Break => {},
+                Span::Text(text) => {
+                    self.wrapper.write_span(&text);
+                },
+                Span::Code(code) => {
+                    self.push_attr(Attr::Bold);
+                    self.wrapper.write_word(&code);
+                    self.pop_attr();
+                },
+                Span::Emphasis(spans) => {
+                    self.push_attr(Attr::ForegroundColor(color::BRIGHT_RED));
+                    self.do_spans(spans);
+                    self.pop_attr();
+                }
+                _ => {}
+            }
+        }
+    }
+    fn do_block(&mut self, b: Block) {
+        match b {
+            Block::Header(spans, _) => {
+                self.push_attr(Attr::ForegroundColor(color::BRIGHT_WHITE));
+                self.wrapper.write_line();
+                self.do_spans(spans);
+                self.wrapper.write_line();
+                self.pop_attr();
+            },
+            Block::CodeBlock(code) => {
+                self.wrapper.write_line();
+                self.wrapper.indent += 2;
+                for line in code.lines() {
+                    // Don't word-wrap code lines
+                    self.wrapper.write_word(line);
+                    self.wrapper.write_line();
+                }
+                self.wrapper.indent -= 2;
+            },
+            Block::Paragraph(spans) => {
+                self.wrapper.write_line();
+                self.do_spans(spans);
+                self.wrapper.write_line();
+            },
+            Block::UnorderedList(items) => {
+                self.wrapper.write_line();
+                for item in items {
+                    self.wrapper.indent += 2;
+                    match item {
+                        ListItem::Simple(spans) => {
+                            self.do_spans(spans);
+                        },
+                        ListItem::Paragraph(blocks) => {
+                            for block in blocks {
+                                self.do_block(block);
+                            }
+                        }
+                    }
+                    self.wrapper.write_line();
+                    self.wrapper.indent -= 2;
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+impl<T: Instantiable + io::Write> io::Write for Terminal<T> {
     fn write(&mut self, buf: &[u8]) -> Result<usize, io::Error> {
         if let Some(ref mut t) = self.0 {
             t.write(buf)
         } else {
-            let mut t = io::stdout();
+            let mut t = T::instance();
             t.write(buf)
         }
     }
@@ -34,33 +215,13 @@ impl io::Write for StdoutTerminal {
         if let Some(ref mut t) = self.0 {
             t.flush()
         } else {
-            let mut t = io::stdout();
+            let mut t = T::instance();
             t.flush()
         }
     }
 }
 
-impl io::Write for StderrTerminal {
-    fn write(&mut self, buf: &[u8]) -> Result<usize, io::Error> {
-        if let Some(ref mut t) = self.0 {
-            t.write(buf)
-        } else {
-            let mut t = io::stderr();
-            t.write(buf)
-        }
-    }
-
-    fn flush(&mut self) -> Result<(), io::Error> {
-        if let Some(ref mut t) = self.0 {
-            t.flush()
-        } else {
-            let mut t = io::stdout();
-            t.flush()
-        }
-    }
-}
-
-impl StdoutTerminal {
+impl<T: Instantiable + io::Write> Terminal<T> {
     pub fn fg(&mut self, color: color::Color) -> Result<(), term::Error> {
         if !tty::stderr_isatty() { return Ok(()) }
 
@@ -75,7 +236,15 @@ impl StdoutTerminal {
         if !tty::stderr_isatty() { return Ok(()) }
 
         if let Some(ref mut t) = self.0 {
-            t.attr(attr)
+            if let Err(e) = t.attr(attr) {
+                // If `attr` is not supported, try to emulate it
+                match attr {
+                    Attr::Bold => t.fg(color::BRIGHT_WHITE),
+                    _ => Err(e)
+                }
+            } else {
+                Ok(())
+            }
         } else {
             Ok(())
         }
@@ -90,37 +259,12 @@ impl StdoutTerminal {
             Ok(())
         }
     }
-}
 
-impl StderrTerminal {
-    pub fn fg(&mut self, color: color::Color) -> Result<(), term::Error> {
-        if !tty::stderr_isatty() { return Ok(()) }
-
-        if let Some(ref mut t) = self.0 {
-            t.fg(color)
-        } else {
-            Ok(())
-        }
-    }
-
-    pub fn attr(&mut self, attr: Attr) -> Result<(), term::Error> {
-        if !tty::stderr_isatty() { return Ok(()) }
-
-        if let Some(ref mut t) = self.0 {
-            t.attr(attr)
-        } else {
-            Ok(())
-        }
-    }
-
-    pub fn reset(&mut self) -> Result<(), term::Error> {
-        if !tty::stderr_isatty() { return Ok(()) }
-
-        if let Some(ref mut t) = self.0 {
-            t.reset()
-        } else {
-            Ok(())
+    pub fn md<S: AsRef<str>>(&mut self, content: S) {
+        let mut f = LineFormatter::new(self, 0, 80);
+        let blocks = tokenize(content.as_ref());
+        for b in blocks {
+            f.do_block(b);
         }
     }
 }
-

--- a/src/rustup-cli/term2.rs
+++ b/src/rustup-cli/term2.rs
@@ -82,7 +82,11 @@ impl<'a, T: io::Write + 'a> LineWrapper<'a, T> {
     }
     fn write_space(&mut self) {
         if self.pos > self.indent {
-            self.write_word(" ");
+            if self.pos < self.margin {
+                self.write_word(" ");
+            } else {
+                self.write_line();
+            }
         }
     }
     // Writes a span of text which wraps at the margin

--- a/tests/cli-install-interactive.rs
+++ b/tests/cli-install-interactive.rs
@@ -80,10 +80,11 @@ fn blank_lines_around_stderr_log_output_install() {
         // output on stderr, then an explicit blank line on stdout
         // before printing $toolchain installed
         assert!(out.stdout.contains(r"
-Press the Enter key to install Rust.
+3) Cancel installation
 
 
   stable installed - 1.1.0 (hash-s-2)
+
 
 Rust is installed now. Great!
 "));
@@ -97,7 +98,8 @@ fn blank_lines_around_stderr_log_output_update() {
         let out = run_input(config, &["rustup-init"], "\n\n");
 
         assert!(out.stdout.contains(r"
-Press the Enter key to install Rust.
+3) Cancel installation
+
 
 
 Rust is installed now. Great!
@@ -141,7 +143,7 @@ fn with_non_default_toolchain() {
 fn set_nightly_toolchain() {
     setup(&|config| {
         let out = run_input(config, &["rustup-init"],
-                            "a\nnightly\n\n\n\n");
+                            "2\nnightly\n\n\n\n");
         assert!(out.ok);
 
         expect_stdout_ok(config, &["rustup", "show"], "nightly");
@@ -152,7 +154,7 @@ fn set_nightly_toolchain() {
 fn set_no_modify_path() {
     setup(&|config| {
         let out = run_input(config, &["rustup-init"],
-                            "a\n\nno\n\n\n");
+                            "2\n\nno\n\n\n");
         assert!(out.ok);
 
         if cfg!(unix) {
@@ -165,7 +167,7 @@ fn set_no_modify_path() {
 fn set_nightly_toolchain_and_unset() {
     setup(&|config| {
         let out = run_input(config, &["rustup-init"],
-                            "a\nnightly\n\na\nbeta\n\n\n\n");
+                            "2\nnightly\n\n2\nbeta\n\n\n\n");
         assert!(out.ok);
 
         expect_stdout_ok(config, &["rustup", "show"], "beta");
@@ -176,7 +178,7 @@ fn set_nightly_toolchain_and_unset() {
 fn user_says_nope_after_advanced_install() {
     setup(&|config| {
         let out = run_input(config, &["rustup-init"],
-                            "a\n\n\nn\n\n");
+                            "2\n\n\nn\n\n");
         assert!(out.ok);
         assert!(!config.cargodir.join("bin").exists());
     });


### PR DESCRIPTION
- Removes some code duplication from `term2`
- Uses `markdown` to parse markdown-style text and display formatted output in the terminal
- Implements a word-wrap algorithm
- Shows install options before asking whether to customize
- Uses numbered choices rather than letters

The markdown crate exposes a `tokenize` method which seems to be exactly fit for purpose. However, it exposes a private type in the return value which makes it unusable. I've opened an issue about it, but for the moment I've had to fork it and use a git dependency.

r? @brson 