### PR TITLE
Add a disclaimer to the www about curl | sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,9 +425,11 @@ variable.
 
 ## Security
 
-`rustup` is secure enough for the non-paranoid, but it still needs
-work. `rustup` performs all downloads over HTTPS, but does not
+`rustup` is secure enough for the non-paranoid, but it [still needs
+work][s]. `rustup` performs all downloads over HTTPS, but does not
 yet validate signatures of downloads.
+
+[s]: https://github.com/rust-lang-nursery/rustup.rs/issues?q=is%3Aopen+is%3Aissue+label%3Asecurity
 
 ## FAQ
 

--- a/www/index.html
+++ b/www/index.html
@@ -24,14 +24,20 @@
 </p>
 
 <div id="platform-instructions-unix" class="instructions" style="display: none;">
-  <p>Run the following in your terminal, then follow the onscreen instructions.</p>
+  <p>Run the following in your terminal<sup>†</sup>, then follow the onscreen instructions.</p>
   <pre>curl https://sh.rustup.rs -sSf | sh</pre>
+  <p id="sh-disclaimer">
+    <sup>†</sup>
+    <a href="https://sandstorm.io/news/2015-09-24-is-curl-bash-insecure-pgp-verified-install">
+      On the security of <code>curl | sh</code>
+    </a>
+  </p>
 </div>
 
 <div id="platform-instructions-win" class="instructions" style="display: none;">
   <p>
     Download and run
-    <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+    <a class="rustup-link" href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
     then follow the onscreen instructions.
   </p>
 </div>
@@ -67,8 +73,14 @@
 
 <div id="platform-instructions-default" class="instructions">
   <div>
-    <p>If you are running Unix,<br/>run the following in your terminal, then follow the onscreen instructions.</p>
+    <p>If you are running Unix,<br/>run the following in your terminal<sup>†</sup>, then follow the onscreen instructions.</p>
     <pre>curl https://sh.rustup.rs -sSf | sh</pre>
+    <p id="sh-disclaimer">
+      <sup>†</sup>
+      <a href="https://sandstorm.io/news/2015-09-24-is-curl-bash-insecure-pgp-verified-install">
+        On the security of <code>curl | sh</code>
+      </a>
+    </p>
   </div>
 
   <hr/>
@@ -76,7 +88,7 @@
   <div>
     <p>
       If you are running Windows,<br/>download and run
-      <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+      <a class="rustup-link" href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
       then follow the onscreen instructions.
     </p>
   </div>

--- a/www/rustup.css
+++ b/www/rustup.css
@@ -67,7 +67,7 @@ body#idx > * {
 }
 
 body#idx > #pitch {
-    width: 30em;
+    width: 30rem;
 }
 
 #pitch em {
@@ -84,7 +84,7 @@ body#idx p {
     background-color: rgb(250, 250, 250);
     margin-left: auto;
     margin-right: auto;
-    width: 30em;
+    width: 30rem;
     text-align: center;
     border-radius: 3px;
     border: 1px solid rgb(204, 204, 204);
@@ -92,7 +92,7 @@ body#idx p {
 }
 
 .instructions > * {
-    width: 22em;
+    width: 34rem;
     margin-left: auto;
     margin-right: auto;
 }
@@ -108,8 +108,8 @@ hr {
     color: white;
     margin-left: auto;
     margin-right: auto;
-    padding-top: 1em;
-    padding-bottom: 1em;
+    padding-top: 1rem;
+    padding-bottom: 1rem;
     text-align: center;
     border-radius: 3px;
     box-shadow: inset 0px 0px 20px 0px #333333;
@@ -118,16 +118,16 @@ hr {
 #platform-instructions-win a,
 #platform-instructions-default a {
     display: block;
-    padding-top: 0.4em;
-    padding-bottom: 0.6em;
+    padding-top: 0.4rem;
+    padding-bottom: 0.6rem;
     font-family: "Work Sans", "Fira Sans","Helvetica Neue",Helvetica,Arial,sans-serif;
     font-weight: 500;
-    letter-spacing: 0.1em;
+    letter-spacing: 0.1rem;
 }
 
 #platform-instructions-unknown div {
     font-size: 16px;
-    line-height: 2em;
+    line-height: 2rem;
 }
 
 #warning {
@@ -149,7 +149,6 @@ hr {
 #platform-button {
     background-color: #515151;
     color: white;
-    width: 10em;
     margin-left: auto;
     margin-right: auto;
     padding: 1em;

--- a/www/rustup.css
+++ b/www/rustup.css
@@ -115,8 +115,8 @@ hr {
     box-shadow: inset 0px 0px 20px 0px #333333;
 }
 
-#platform-instructions-win a,
-#platform-instructions-default a {
+#platform-instructions-win .rustup-link,
+#platform-instructions-default .rustup-link {
     display: block;
     padding-top: 0.4rem;
     padding-bottom: 0.6rem;
@@ -128,6 +128,12 @@ hr {
 #platform-instructions-unknown div {
     font-size: 16px;
     line-height: 2rem;
+}
+
+#sh-disclaimer {
+    font-size: 14px;
+    padding-top: 20px;
+    padding-bottom: 10px;
 }
 
 #warning {


### PR DESCRIPTION
Since there's going to be a blog post about rustup out soon, this is to get ahead of the complaining about `curl | sh`.

I intend to remove this from the website again after the discussion from the blog post dies down because it's a distraction from the actual installation instructions.