### PR TITLE
Remove redundant OpenSSL CA initialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,7 +388,6 @@ dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "ole32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "scopeguard 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/rustup-utils/Cargo.toml
+++ b/src/rustup-utils/Cargo.toml
@@ -21,9 +21,6 @@ sha2 = "0.1.2"
 curl = { git = "https://github.com/alexcrichton/curl-rust", branch = "rewrite" }
 url = "1.1"
 
-[target.'cfg(not(any(target_os = "windows", target_os = "macos")))'.dependencies]
-openssl-sys = "0.7.11"
-
 [target."cfg(windows)".dependencies]
 winapi = "0.2.4"
 winreg = "0.3.2"

--- a/src/rustup-utils/src/lib.rs
+++ b/src/rustup-utils/src/lib.rs
@@ -9,8 +9,6 @@ extern crate scopeguard;
 extern crate error_chain;
 extern crate rustc_serialize;
 extern crate sha2;
-#[cfg(not(any(target_os = "windows", target_os = "macos")))]
-extern crate openssl_sys;
 extern crate url;
 
 #[cfg(windows)]

--- a/src/rustup-utils/src/raw.rs
+++ b/src/rustup-utils/src/raw.rs
@@ -163,8 +163,6 @@ pub fn download_file(url: &Url,
     use notifications::Notification;
     use std::io::Write;
 
-    maybe_init_certs();
-
     let mut file = try!(fs::File::create(&path).chain_err(
         || "error creating file for download"));
     let fserr = RefCell::new(None);
@@ -243,20 +241,6 @@ pub fn download_file(url: &Url,
     notify_handler.call(Notification::DownloadFinished);
     Ok(())
 }
-
-// Tell our statically-linked OpenSSL where to find root certs
-// cc https://github.com/alexcrichton/git2-rs/blob/master/libgit2-sys/lib.rs#L1267
-#[cfg(not(any(target_os = "windows", target_os = "macos")))]
-fn maybe_init_certs() {
-    use std::sync::{Once, ONCE_INIT};
-    static INIT: Once = ONCE_INIT;
-    INIT.call_once(|| {
-        ::openssl_sys::probe::init_ssl_cert_env_vars();
-    });
-}
-
-#[cfg(any(target_os = "windows", target_os = "macos"))]
-fn maybe_init_certs() { }
 
 pub fn symlink_dir(src: &Path, dest: &Path) -> io::Result<()> {
     #[cfg(windows)]


### PR DESCRIPTION
curl finds the local root certs on its own