### PR TITLE
Don't install when multirust metadata exists. Fixes #424

### DIFF
--- a/tests/cli-self-update.rs
+++ b/tests/cli-self-update.rs
@@ -1077,3 +1077,15 @@ fn install_but_rustup_sh_is_installed() {
                    "cannot install while rustup.sh is installed");
     });
 }
+
+#[test]
+fn install_but_multirust_metadata() {
+    setup(&|config| {
+        let multirust_dir = config.homedir.join(".multirust");
+        fs::create_dir_all(&multirust_dir).unwrap();
+        let version_file = multirust_dir.join("version");
+        raw::write_file(&version_file, "2").unwrap();
+        expect_err(config, &["rustup-init", "-y"],
+                   "cannot install while multirust is installed");
+    });
+}


### PR DESCRIPTION
This is the case where .multirust exists and is out of date,
but multirust bins are no longer installed. This happens because
multirust uninstall doesn't remove metadata.

r? @alexcrichton I want to try to get out one more build before tomorrow with this fix.