### PR TITLE
Prioritize adding path to '.bash_profile' over '.profile'.

### DIFF
--- a/src/rustup-cli/self_update.rs
+++ b/src/rustup-cli/self_update.rs
@@ -795,7 +795,16 @@ fn get_add_path_methods() -> Vec<PathUpdateMethod> {
         return vec![PathUpdateMethod::Windows];
     }
 
-    let profile = utils::home_dir().map(|p| p.join(".profile"));
+    let mut bash_profile = utils::home_dir().unwrap();
+    bash_profile.push(".bash_profile");
+
+    let profile;
+    match bash_profile.exists()
+    {
+        true => profile = utils::home_dir().map(|p| p.join(".bash_profile")),
+        _ => profile = utils::home_dir().map(|p| p.join(".profile"))
+    }
+        
     let rcfiles = vec![profile].into_iter().filter_map(|f|f);
 
     rcfiles.map(|f| PathUpdateMethod::RcFile(f)).collect()

--- a/src/rustup-cli/self_update.rs
+++ b/src/rustup-cli/self_update.rs
@@ -374,10 +374,9 @@ fn pre_install_msg(no_modify_path: bool) -> Result<String> {
                         None
                     }
                 }).collect::<Vec<_>>();
-            assert!(rcfiles.len() == 1); // Only modifying .profile
             Ok(format!(pre_install_msg_unix!(),
                        cargo_home_bin = cargo_home_bin.display(),
-                       rcfiles = rcfiles[0]))
+                       rcfiles = rcfiles.join(", ")))
         } else {
             Ok(format!(pre_install_msg_win!(),
                        cargo_home_bin = cargo_home_bin.display()))
@@ -795,19 +794,23 @@ fn get_add_path_methods() -> Vec<PathUpdateMethod> {
         return vec![PathUpdateMethod::Windows];
     }
 
-    let mut bash_profile = utils::home_dir().unwrap();
-    bash_profile.push(".bash_profile");
+    let profiles = vec![".bash_profile", ".bash_login", ".profile"];
 
-    let profile;
-    match bash_profile.exists()
+    let mut rcfiles: Vec<PathUpdateMethod> = vec![];
+    for filename in profiles 
     {
-        true => profile = utils::home_dir().map(|p| p.join(".bash_profile")),
-        _ => profile = utils::home_dir().map(|p| p.join(".profile"))
-    }
-        
-    let rcfiles = vec![profile].into_iter().filter_map(|f|f);
+        let mut path = utils::home_dir().unwrap();
+        path.push(filename);
 
-    rcfiles.map(|f| PathUpdateMethod::RcFile(f)).collect()
+        if path.exists()
+        {
+            let profile = utils::home_dir().map(|p| p.join(filename));
+
+            rcfiles.push(PathUpdateMethod::RcFile(profile.unwrap()));
+        }
+    }
+
+    rcfiles
 }
 
 fn shell_export_string() -> Result<String> {


### PR DESCRIPTION
If you use '.bash_profile' on osx, '.profile' gets ignored, which prevents the changes to $PATH from being picked up. 

I don't have any experience in rust, so this code may not be idiomatic.