### PR TITLE
rm `.`

### DIFF
--- a/src/rustup-cli/rustup_mode.rs
+++ b/src/rustup-cli/rustup_mode.rs
@@ -229,7 +229,7 @@ pub fn cli() -> App<'static, 'static> {
             .arg(Arg::with_name("command")
                 .required(true)))
         .subcommand(SubCommand::with_name("doc")
-            .about("Open the documentation for the current toolchain.")
+            .about("Open the documentation for the current toolchain")
             .after_help(DOC_HELP)
             .arg(Arg::with_name("book")
                  .long("book")


### PR DESCRIPTION
Just keep all use hint in same format:

```
rustup 0.1.12 (c6e430a 2016-05-12)
The Rust toolchain installer

USAGE:
    rustup [FLAGS] [SUBCOMMAND]

FLAGS:
    -v, --verbose    Enable verbose output
    -h, --help       Prints help information
    -V, --version    Prints version information

SUBCOMMANDS:
    show         Show the active and installed toolchains
    update       Update Rust toolchains
    default      Set the default toolchain
    toolchain    Modify or query the installed toolchains
    target       Modify a toolchain's supported targets
    override     Modify directory toolchain overrides
    run          Run a command with an environment configured for a given toolchain
    which        Display which binary will be run for a given command
    doc          Open the documentation for the current toolchain
    self         Modify the rustup installation
    telemetry    rustup telemetry commands
    help         Prints this message or the help of the given subcommand(s)

rustup installs The Rust Programming Language from the official
release channels, enabling you to easily switch between stable, beta,
and nightly compilers and keep them updated. It makes cross-compiling
simpler with binary builds of the standard library for common platforms.

If you are new to Rust consider running `rustup doc --book`
to learn Rust.

```