### PR TITLE
Adding TOOLCHAIN_HELP to rustup help install

### DIFF
--- a/src/rustup-cli/help.rs
+++ b/src/rustup-cli/help.rs
@@ -25,7 +25,19 @@ stable, beta, and nightly toolchains from the official release
 channels, then updates rustup itself.
 
 If given a toolchain argument then `update` updates that toolchain,
-the same as `rustup toolchain update`.";
+the same as `rustup toolchain update`.
+
+'toolchain' specifies a toolchain name, such as 'stable', 'nightly',
+or '1.8.0'. For more information see `rustup help toolchain`.";
+
+pub static TOOLCHAIN_INSTALL_HELP: &'static str =
+r"
+Installs a specific rust toolchain.
+
+The 'install' command is an alias for 'rustup update <toolchain>'.
+
+'toolchain' specifies a toolchain name, such as 'stable', 'nightly',
+or '1.8.0'. For more information see `rustup help toolchain`.";
 
 pub static DEFAULT_HELP: &'static str =
 r"

--- a/src/rustup-cli/rustup_mode.rs
+++ b/src/rustup-cli/rustup_mode.rs
@@ -113,6 +113,7 @@ pub fn cli() -> App<'static, 'static> {
             .after_help(SHOW_HELP))
         .subcommand(SubCommand::with_name("install")
             .about("Update Rust toolchains")
+            .after_help(TOOLCHAIN_HELP)
             .setting(AppSettings::Hidden) // synonym for 'toolchain install'
             .arg(Arg::with_name("toolchain")
                 .required(true)))

--- a/src/rustup-cli/rustup_mode.rs
+++ b/src/rustup-cli/rustup_mode.rs
@@ -113,7 +113,7 @@ pub fn cli() -> App<'static, 'static> {
             .after_help(SHOW_HELP))
         .subcommand(SubCommand::with_name("install")
             .about("Update Rust toolchains")
-            .after_help(TOOLCHAIN_HELP)
+            .after_help(TOOLCHAIN_INSTALL_HELP)
             .setting(AppSettings::Hidden) // synonym for 'toolchain install'
             .arg(Arg::with_name("toolchain")
                 .required(true)))


### PR DESCRIPTION
Adds the help from `TOOLCHAIN_HELP` to `rustup help install`. There are likely other places we can add this and get additional help about `<toolchain>` into rustup.

This should fix https://github.com/rust-lang-nursery/rustup.rs/issues/483