### PR TITLE
Filter whitespace lines from components file.

### DIFF
--- a/src/rustup-dist/src/component/components.rs
+++ b/src/rustup-dist/src/component/components.rs
@@ -61,6 +61,7 @@ impl Components {
         }
         let content = try!(utils::read_file("components", &path));
         Ok(content.lines()
+                  .filter(|s| s.chars().all(char::is_whitespace))
                   .map(|s| {
                       Component {
                           components: self.clone(),


### PR DESCRIPTION
Old versions of multirust may have inserted an extra new-line character
into the components file. This makes upgrade robust to files that
contain whitespace lines by not attempting to construct components with
empty names.