### PR TITLE
Change upstream via $RUSTUP_DIST_SERVER

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,10 +357,13 @@ Command | Description
   invocations. A toolchain with this name should be installed, or
   invocations will fail.
 
-- `RUSTUP_DIST_ROOT` (default: `https://static.rust-lang.org/dist`)
-  Sets the root URL for downloading Rust toolchains and release
-  channel updates. You can change this to instead use a local mirror,
+- `RUSTUP_DIST_SERVER` (default: `https://static.rust-lang.org`)
+  Sets the root URL for downloading static resources related to Rust.
+  You can change this to instead use a local mirror,
   or to test the binaries from the staging directory.
+
+- `RUSTUP_DIST_ROOT` (default: `https://static.rust-lang.org/dist`)
+  Deprecated. Use `RUSTUP_DIST_SERVER` instead.
 
 - `RUSTUP_UPDATE_ROOT` (default `https://static.rust-lang.org/rustup/dist`)
   Sets the root URL for downloading self-updates.

--- a/src/rustup-dist/src/dist.rs
+++ b/src/rustup-dist/src/dist.rs
@@ -15,8 +15,11 @@ use std::env;
 use regex::Regex;
 use sha2::{Sha256, Digest};
 
-pub const DEFAULT_DIST_ROOT: &'static str = "https://static.rust-lang.org/dist";
+pub const DEFAULT_DIST_SERVER: &'static str = "https://static.rust-lang.org";
 pub const UPDATE_HASH_LEN: usize = 20;
+
+// Deprecated
+pub const DEFAULT_DIST_ROOT: &'static str = "https://static.rust-lang.org/dist";
 
 // A toolchain descriptor from rustup's perspective. These contain
 // 'partial target triples', which allow toolchain names like

--- a/src/rustup-dist/src/temp.rs
+++ b/src/rustup-dist/src/temp.rs
@@ -37,6 +37,7 @@ pub enum Notification<'a> {
 
 pub struct Cfg {
     root_directory: PathBuf,
+    pub dist_server: String,
     notify_handler: Box<Fn(Notification)>,
 }
 
@@ -131,9 +132,10 @@ impl Display for Error {
 }
 
 impl Cfg {
-    pub fn new(root_directory: PathBuf, notify_handler: Box<Fn(Notification)>) -> Self {
+    pub fn new(root_directory: PathBuf, dist_server: &str, notify_handler: Box<Fn(Notification)>) -> Self {
         Cfg {
             root_directory: root_directory,
+            dist_server: dist_server.to_owned(),
             notify_handler: notify_handler,
         }
     }

--- a/src/rustup-dist/tests/dist.rs
+++ b/src/rustup-dist/tests/dist.rs
@@ -17,7 +17,7 @@ use rustup_mock::{MockCommand, MockInstallerBuilder};
 use rustup_dist::prefix::InstallPrefix;
 use rustup_dist::ErrorKind;
 use rustup_dist::errors::Result;
-use rustup_dist::dist::{ToolchainDesc, TargetTriple};
+use rustup_dist::dist::{ToolchainDesc, TargetTriple, DEFAULT_DIST_SERVER};
 use rustup_dist::download::DownloadCfg;
 use rustup_dist::Notification;
 use rustup_utils::utils;
@@ -319,6 +319,7 @@ fn setup(edit: Option<&Fn(&str, &mut MockPackage)>,
 
     let work_tempdir = TempDir::new("multirust").unwrap();
     let ref temp_cfg = temp::Cfg::new(work_tempdir.path().to_owned(),
+                                      DEFAULT_DIST_SERVER,
                                       Box::new(|_| ()));
 
     let ref url = Url::parse(&format!("file://{}", dist_tempdir.path().to_string_lossy())).unwrap();

--- a/src/rustup-dist/tests/install.rs
+++ b/src/rustup-dist/tests/install.rs
@@ -6,6 +6,7 @@ extern crate tempdir;
 use rustup_dist::component::Components;
 use rustup_dist::component::{DirectoryPackage, Package};
 use rustup_dist::component::Transaction;
+use rustup_dist::dist::DEFAULT_DIST_SERVER;
 use rustup_dist::temp;
 use rustup_dist::ErrorKind;
 use rustup_dist::Notification;
@@ -109,7 +110,7 @@ fn basic_install() {
     let prefix = InstallPrefix::from(instdir.path().to_owned());
 
     let tmpdir = TempDir::new("multirust").unwrap();
-    let tmpcfg = temp::Cfg::new(tmpdir.path().to_owned(), Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(tmpdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
     let notify = |_: Notification| ();
     let tx = Transaction::new(prefix.clone(), &tmpcfg, &notify);
 
@@ -147,7 +148,7 @@ fn multiple_component_install() {
     let prefix = InstallPrefix::from(instdir.path().to_owned());
 
     let tmpdir = TempDir::new("multirust").unwrap();
-    let tmpcfg = temp::Cfg::new(tmpdir.path().to_owned(), Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(tmpdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
     let notify = |_: Notification| ();
     let tx = Transaction::new(prefix.clone(), &tmpcfg, &notify);
 
@@ -190,7 +191,7 @@ fn uninstall() {
     let prefix = InstallPrefix::from(instdir.path().to_owned());
 
     let tmpdir = TempDir::new("multirust").unwrap();
-    let tmpcfg = temp::Cfg::new(tmpdir.path().to_owned(), Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(tmpdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
     let notify = |_: Notification| ();
     let tx = Transaction::new(prefix.clone(), &tmpcfg, &notify);
 
@@ -242,7 +243,7 @@ fn component_bad_version() {
     let prefix = InstallPrefix::from(instdir.path().to_owned());
 
     let tmpdir = TempDir::new("multirust").unwrap();
-    let tmpcfg = temp::Cfg::new(tmpdir.path().to_owned(), Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(tmpdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
     let notify = |_: Notification| ();
     let tx = Transaction::new(prefix.clone(), &tmpcfg, &notify);
 
@@ -288,7 +289,7 @@ fn unix_permissions() {
     let prefix = InstallPrefix::from(instdir.path().to_owned());
 
     let tmpdir = TempDir::new("multirust").unwrap();
-    let tmpcfg = temp::Cfg::new(tmpdir.path().to_owned(), Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(tmpdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
     let notify = |_: Notification| ();
     let tx = Transaction::new(prefix.clone(), &tmpcfg, &notify);
 
@@ -332,7 +333,7 @@ fn install_to_prefix_that_does_not_exist() {
     let prefix = InstallPrefix::from(does_not_exist.clone());
 
     let tmpdir = TempDir::new("multirust").unwrap();
-    let tmpcfg = temp::Cfg::new(tmpdir.path().to_owned(), Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(tmpdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
     let notify = |_: Notification| ();
     let tx = Transaction::new(prefix.clone(), &tmpcfg, &notify);
 

--- a/src/rustup-dist/tests/transactions.rs
+++ b/src/rustup-dist/tests/transactions.rs
@@ -4,11 +4,12 @@ extern crate tempdir;
 
 use rustup_dist::prefix::InstallPrefix;
 use rustup_dist::component::Transaction;
+use rustup_dist::dist::DEFAULT_DIST_SERVER;
 use rustup_dist::temp;
 use rustup_dist::Notification;
+use rustup_dist::ErrorKind;
 use rustup_utils::utils;
 use rustup_utils::raw as utils_raw;
-use rustup_dist::ErrorKind;
 use tempdir::TempDir;
 use std::fs;
 use std::io::Write;
@@ -21,7 +22,7 @@ fn add_file() {
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
 
     let notify = |_: Notification| ();
     let mut tx = Transaction::new(prefix.clone(), &tmpcfg, &notify);
@@ -43,7 +44,7 @@ fn add_file_then_rollback() {
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
 
     let notify = |_: Notification| ();
     let mut tx = Transaction::new(prefix.clone(), &tmpcfg, &notify);
@@ -59,7 +60,7 @@ fn add_file_that_exists() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -86,7 +87,7 @@ fn copy_file() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -108,7 +109,7 @@ fn copy_file_then_rollback() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -130,7 +131,7 @@ fn copy_file_that_exists() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -160,7 +161,7 @@ fn copy_dir() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -190,7 +191,7 @@ fn copy_dir_then_rollback() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -220,7 +221,7 @@ fn copy_dir_that_exists() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -245,7 +246,7 @@ fn remove_file() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -266,7 +267,7 @@ fn remove_file_then_rollback() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -287,7 +288,7 @@ fn remove_file_that_not_exists() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -310,7 +311,7 @@ fn remove_dir() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -332,7 +333,7 @@ fn remove_dir_then_rollback() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -354,7 +355,7 @@ fn remove_dir_that_not_exists() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -377,7 +378,7 @@ fn write_file() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -399,7 +400,7 @@ fn write_file_then_rollback() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -418,7 +419,7 @@ fn write_file_that_exists() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -445,7 +446,7 @@ fn modify_file_that_not_exists() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -465,7 +466,7 @@ fn modify_file_that_exists() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -485,7 +486,7 @@ fn modify_file_that_not_exists_then_rollback() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -503,7 +504,7 @@ fn modify_file_that_exists_then_rollback() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -526,7 +527,7 @@ fn modify_twice_then_rollback() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -549,7 +550,7 @@ fn do_multiple_op_transaction(rollback: bool) {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -645,7 +646,7 @@ fn rollback_failure_keeps_going() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 

--- a/src/rustup-mock/src/clitools.rs
+++ b/src/rustup-mock/src/clitools.rs
@@ -226,7 +226,7 @@ pub fn cmd(config: &Config, name: &str, args: &[&str]) -> Command {
 
 pub fn env(config: &Config, cmd: &mut Command) {
     cmd.env("RUSTUP_HOME", config.rustupdir.to_string_lossy().to_string());
-    cmd.env("RUSTUP_DIST_ROOT", format!("file://{}", config.distdir.join("dist").to_string_lossy()));
+    cmd.env("RUSTUP_DIST_SERVER", format!("file://{}", config.distdir.to_string_lossy()));
     cmd.env("CARGO_HOME", config.cargodir.to_string_lossy().to_string());
     cmd.env("RUSTUP_OVERRIDE_HOST_TRIPLE", this_host_triple());
 


### PR DESCRIPTION
The downloads from the original https://static.rust-lang.org/ are rather slow in some regions, e.g. China. It is reasonable to enable users to choose other mirror sites.


Besides, I doubt that setting `RUSTUP_DIST_ROOT` is able to alter the root URL for downloading Rust toolchains and updates, since the urls written in the manifest files are still something like `https://static.rust-lang.org/dist/2016-05-24/rust-1.9.0-aarch64-unknown-linux-gnu.tar.gz`, which makes no difference.