### PR TITLE
missing curly brace in docs of error-chain

### DIFF
--- a/src/error-chain/src/lib.rs
+++ b/src/error-chain/src/lib.rs
@@ -195,6 +195,7 @@
 //!
 //! fn bar() -> Result<()> {
 //!     Ok(try!(Err("bogus!")))
+//! }
 //! ```
 //!
 //! ## Chaining errors


### PR DESCRIPTION
Self explanatory.

In addition to #519 this should fix a lot of the docs' typos.…
