### PR TITLE
Reduce margin

### DIFF
--- a/src/rustup-cli/term2.rs
+++ b/src/rustup-cli/term2.rs
@@ -265,7 +265,7 @@ impl<T: Instantiable + io::Write> Terminal<T> {
     }
 
     pub fn md<S: AsRef<str>>(&mut self, content: S) {
-        let mut f = LineFormatter::new(self, 0, 80);
+        let mut f = LineFormatter::new(self, 0, 79);
         let blocks = tokenize(content.as_ref());
         for b in blocks {
             f.do_block(b);


### PR DESCRIPTION
80 characters followed by a newline will result in an extra blank line in an 80 character `cmd` terminal. Since this is the default width, we should reduce the margin to 79 characters.

Fixes #525 