### PR TITLE
When listing toolchains only list directories

### DIFF
--- a/src/rustup-mock/src/clitools.rs
+++ b/src/rustup-mock/src/clitools.rs
@@ -171,6 +171,17 @@ pub fn expect_stdout_ok(config: &Config, args: &[&str], expected: &str) {
     assert!(out.stdout.contains(expected), args);
 }
 
+pub fn expect_not_stdout_ok(config: &Config, args: &[&str], expected: &str) {
+    let out = run(config, args[0], &args[1..], &[]);
+    println!("out.ok: {}", out.ok);
+    println!("out.stdout:\n\n{}", out.stdout);
+    println!("out.stderr:\n\n{}", out.stderr);
+    println!("expected: {}", expected);
+    let args = format!("{:?}", args);
+    assert!(out.ok, args);
+    assert!(! out.stdout.contains(expected), args);
+}
+
 pub fn expect_stderr_ok(config: &Config, args: &[&str], expected: &str) {
     let out = run(config, args[0], &args[1..], &[]);
     println!("out.ok: {}", out.ok);

--- a/src/rustup/config.rs
+++ b/src/rustup/config.rs
@@ -252,6 +252,7 @@ impl Cfg {
         if utils::is_directory(&self.toolchains_dir) {
             let mut toolchains: Vec<_> = try!(utils::read_dir("toolchains", &self.toolchains_dir))
                                          .filter_map(io::Result::ok)
+                                         .filter(|e| e.file_type().map(|f| f.is_dir()).unwrap_or(false))
                                          .filter_map(|e| e.file_name().into_string().ok())
                                          .collect();
 

--- a/tests/cli-v2.rs
+++ b/tests/cli-v2.rs
@@ -10,8 +10,9 @@ use std::fs;
 use tempdir::TempDir;
 use rustup_mock::clitools::{self, Config, Scenario,
                                expect_ok, expect_stdout_ok, expect_err,
-                               expect_stderr_ok, set_current_dist_date,
-                               change_dir, this_host_triple};
+                               expect_stderr_ok, expect_not_stdout_ok,
+                               set_current_dist_date, change_dir,
+                               this_host_triple};
 
 use rustup_dist::dist::TargetTriple;
 
@@ -101,6 +102,20 @@ fn list_toolchains() {
                          "nightly");
         expect_stdout_ok(config, &["rustup", "toolchain", "list"],
                          "beta-2015-01-01");
+    });
+}
+
+#[test]
+fn list_toolchains_with_bogus_file() {
+    // #520
+    setup(&|config| {
+        expect_ok(config, &["rustup", "update", "nightly"]);
+
+        let name = "bogus_regular_file.txt";
+        let path = config.rustupdir.join("toolchains").join(name);
+        rustup_utils::utils::write_file(name, &path, "").unwrap();
+        expect_stdout_ok(config, &["rustup", "toolchain", "list"], "nightly");
+        expect_not_stdout_ok(config, &["rustup", "toolchain", "list"], name);
     });
 }
 


### PR DESCRIPTION
* Regular files in the toolchains directory will not be considered
  valid toolchain names
* If a user opens their $RUSTUP_HOME/toolchains directory with their
  file explorer, the OS may create some files there (e.g. .DS_Store on
  OS X), which we do not want listed as installed toolchains
* Fixes #520