### PR TITLE
Run rustfmt on all source

### DIFF
--- a/src/rustup-cli/cli.rs
+++ b/src/rustup-cli/cli.rs
@@ -9,34 +9,26 @@ pub fn get() -> App<'static, 'static> {
         .about("Port of multirust to rust")
         .setting(AppSettings::VersionlessSubcommands)
         .setting(AppSettings::ArgRequiredElseHelp)
-        .arg(
-            Arg::with_name("verbose")
-                .short("v")
-                .long("verbose")
-                .help("Enable verbose output")
-        )
-        .subcommand(
-            SubCommand::with_name("default")
-                .about("Set the default toolchain.")
-                .after_help(
-r"Sets the default toolchain to the one specified. If the toolchain is
+        .arg(Arg::with_name("verbose")
+            .short("v")
+            .long("verbose")
+            .help("Enable verbose output"))
+        .subcommand(SubCommand::with_name("default")
+            .about("Set the default toolchain.")
+            .after_help(r"Sets the default toolchain to the one specified. If the toolchain is
 not already installed then it is first installed.
 
 If the toolchain is already installed then it is not reinstalled,
 though if installing a custom toolchain with --copy-local,
 --link-local, or --installer then the toolchain is always
 reinstalled.
-"
-                )
-                .arg(Arg::with_name("toolchain").required(true))
-                .args(&install_args())
-                .group(install_group())
-        )
-        .subcommand(
-            SubCommand::with_name("override")
-                .about("Set the toolchain override.")
-                .after_help(
-r"Sets the toolchain that will be used when working at or below the
+")
+            .arg(Arg::with_name("toolchain").required(true))
+            .args(&install_args())
+            .group(install_group()))
+        .subcommand(SubCommand::with_name("override")
+            .about("Set the toolchain override.")
+            .after_help(r"Sets the toolchain that will be used when working at or below the
 current directory. If the toolchain is not already installed then it
 is first installed.
 
@@ -46,181 +38,113 @@ though if installing a custom toolchain with --copy-local,
 reinstalled.
 
 To remove an existing override use `multirust remove-override`.
-"
-                )
-                .arg(Arg::with_name("toolchain").required(true))
-                .args(&install_args())
-                .group(install_group())
-        )
-        .subcommand(
-            SubCommand::with_name("update")
-                .about("Install or update a given toolchain.")
-                .after_help(
-r"With no toolchain specified, the update command updates each of the
+")
+            .arg(Arg::with_name("toolchain").required(true))
+            .args(&install_args())
+            .group(install_group()))
+        .subcommand(SubCommand::with_name("update")
+            .about("Install or update a given toolchain.")
+            .after_help(r"With no toolchain specified, the update command updates each of the
 stable, beta, and nightly toolchains from the official release
 channels, plus any other installed toolchains.
-"
-                )
-                .arg(Arg::with_name("toolchain").required(false))
-                .args(&install_args())
-                .group(install_group())
-        )
-        .subcommand(
-            SubCommand::with_name("show-override")
-                .about("Show information about the current override.")
-        )
-        .subcommand(
-            SubCommand::with_name("show-default")
-                .about("Show information about the current default.")
-        )
-        .subcommand(
-            SubCommand::with_name("list-overrides")
-                .about("List all overrides.")
-        )
-        .subcommand(
-            SubCommand::with_name("list-toolchains")
-                .about("List all installed toolchains.")
-        )
-        .subcommand(
-            SubCommand::with_name("remove-override")
-                .about("Remove an override.")
-                .after_help(
-r"Removes the override for the current directory, or the named
+")
+            .arg(Arg::with_name("toolchain").required(false))
+            .args(&install_args())
+            .group(install_group()))
+        .subcommand(SubCommand::with_name("show-override")
+            .about("Show information about the current override."))
+        .subcommand(SubCommand::with_name("show-default")
+            .about("Show information about the current default."))
+        .subcommand(SubCommand::with_name("list-overrides").about("List all overrides."))
+        .subcommand(SubCommand::with_name("list-toolchains")
+            .about("List all installed toolchains."))
+        .subcommand(SubCommand::with_name("remove-override")
+            .about("Remove an override.")
+            .after_help(r"Removes the override for the current directory, or the named
 override if one is provided.
-"
-                )
-                .arg(Arg::with_name("override").required(false))
-        )
-        .subcommand(
-            SubCommand::with_name("remove-toolchain")
-                .about("Uninstall a toolchain.")
-                .after_help(
-r"Uninstalls an installed toolchain.
-"
-                )
-                .arg(Arg::with_name("toolchain").required(true))
-        )
-        .subcommand(
-            SubCommand::with_name("list-targets")
-                .about("List targets available to install")
-                .after_help(
-r"List the targets available to an installed toolchain.
-"
-                )
-                .arg(Arg::with_name("toolchain").required(true))
-        )
-        .subcommand(
-            SubCommand::with_name("add-target")
-                .about("Add additional compilation targets to an existing toolchain")
-                .after_help(
-r"Adds the standard library for a given platform to an existing
+")
+            .arg(Arg::with_name("override").required(false)))
+        .subcommand(SubCommand::with_name("remove-toolchain")
+            .about("Uninstall a toolchain.")
+            .after_help(r"Uninstalls an installed toolchain.
+")
+            .arg(Arg::with_name("toolchain").required(true)))
+        .subcommand(SubCommand::with_name("list-targets")
+            .about("List targets available to install")
+            .after_help(r"List the targets available to an installed toolchain.
+")
+            .arg(Arg::with_name("toolchain").required(true)))
+        .subcommand(SubCommand::with_name("add-target")
+            .about("Add additional compilation targets to an existing toolchain")
+            .after_help(r"Adds the standard library for a given platform to an existing
 installation.
-"
-                )
-                .arg(Arg::with_name("toolchain").required(true))
-                .arg(Arg::with_name("target").required(true))
-        )
-        .subcommand(
-            SubCommand::with_name("remove-target")
-                .about("Removes compilation targets from an existing toolchain")
-                .after_help(
-r"Removes the standard library for a given platform.
-"
-                )
-                .arg(Arg::with_name("toolchain").required(true))
-                .arg(Arg::with_name("target").required(true))
-        )
-        .subcommand(
-            SubCommand::with_name("run")
-                .setting(AppSettings::TrailingVarArg)
-                .about("Run a command.")
-                .after_help(
-r"Configures an environment to use the given toolchain and then runs
+")
+            .arg(Arg::with_name("toolchain").required(true))
+            .arg(Arg::with_name("target").required(true)))
+        .subcommand(SubCommand::with_name("remove-target")
+            .about("Removes compilation targets from an existing toolchain")
+            .after_help(r"Removes the standard library for a given platform.
+")
+            .arg(Arg::with_name("toolchain").required(true))
+            .arg(Arg::with_name("target").required(true)))
+        .subcommand(SubCommand::with_name("run")
+            .setting(AppSettings::TrailingVarArg)
+            .about("Run a command.")
+            .after_help(r"Configures an environment to use the given toolchain and then runs
 the specified program. The command may be any program, not just
 rustc or cargo. This can be used for testing arbitrary toolchains
 without setting an override.
-"
-                )
-                .arg(Arg::with_name("toolchain").required(true))
-                .arg(Arg::with_name("command").required(true).multiple(true))
-        )
-        .subcommand(
-            SubCommand::with_name("proxy")
-                .setting(AppSettings::TrailingVarArg)
-                .about("Proxy a command.")
-                .after_help(
-r"Configures an environment to use the correct toolchain for the
+")
+            .arg(Arg::with_name("toolchain").required(true))
+            .arg(Arg::with_name("command").required(true).multiple(true)))
+        .subcommand(SubCommand::with_name("proxy")
+            .setting(AppSettings::TrailingVarArg)
+            .about("Proxy a command.")
+            .after_help(r"Configures an environment to use the correct toolchain for the
 current directory, and then runs the specified program. The command
 may be any program, not just rustc or cargo.
-"
-                )
-                .arg(Arg::with_name("command").required(true).multiple(true))
-        )
-        .subcommand(
-            SubCommand::with_name("delete-data")
-                .about("Delete all user metadata.")
-                .after_help(
-r"Removes all installed toolchains, overrides, and aliases for the
+")
+            .arg(Arg::with_name("command").required(true).multiple(true)))
+        .subcommand(SubCommand::with_name("delete-data")
+            .about("Delete all user metadata.")
+            .after_help(r"Removes all installed toolchains, overrides, and aliases for the
 current user.
 
 Prompts for confirmation, unless disabled.
 
 Does not uninstall multirust.
-"
-                )
-                .arg(
-                   Arg::with_name("no-prompt")
-                      .short("y")
-                      .long("yes")
-                      .help("Disable confirmation prompt.")
-                )
-        )
-        .subcommand(
-            SubCommand::with_name("upgrade-data")
-                .about("Upgrade the ~/.multirust directory.")
-                .after_help(
-r"Upgrades the ~/.multirust directory from previous versions.
-"
-                )
-        )
-        .subcommand(
-            SubCommand::with_name("self")
-                .about("Commands for managing multirust itself.")
-                .subcommand(
-                    SubCommand::with_name("uninstall")
-                        .about("Uninstalls multirust.")
-                        .arg(
-                           Arg::with_name("no-prompt")
-                              .short("y")
-                              .long("yes")
-                              .help("Disable confirmation prompt.")
-                        )
-                )
-                .subcommand(
-                    SubCommand::with_name("update")
-                        .about("Updates multirust.")
-                )
-        )
-        .subcommand(
-            SubCommand::with_name("doc")
-                .about("Open the documentation for the current toolchain.")
-                .after_help(
-r"Opens the documentation for the currently active toolchain with the
+")
+            .arg(Arg::with_name("no-prompt")
+                .short("y")
+                .long("yes")
+                .help("Disable confirmation prompt.")))
+        .subcommand(SubCommand::with_name("upgrade-data")
+            .about("Upgrade the ~/.multirust directory.")
+            .after_help(r"Upgrades the ~/.multirust directory from previous versions.
+"))
+        .subcommand(SubCommand::with_name("self")
+            .about("Commands for managing multirust itself.")
+            .subcommand(SubCommand::with_name("uninstall")
+                .about("Uninstalls multirust.")
+                .arg(Arg::with_name("no-prompt")
+                    .short("y")
+                    .long("yes")
+                    .help("Disable confirmation prompt.")))
+            .subcommand(SubCommand::with_name("update").about("Updates multirust.")))
+        .subcommand(SubCommand::with_name("doc")
+            .about("Open the documentation for the current toolchain.")
+            .after_help(r"Opens the documentation for the currently active toolchain with the
 default browser.
 
 By default, it opens the documentation index. Use the various flags to
 open specific pieces of documentation.
-"
-                )
-                .arg(Arg::with_name("book").long("book").help("The Rust Programming Language book"))
-                .arg(Arg::with_name("std").long("std").help("Standard library API documentation"))
-                .group(ArgGroup::with_name("page").args(&["book", "std"]))
-        )
-        .subcommand(
-            SubCommand::with_name("which")
-                .about("Report location of the currently active Rust tool.")
-                .arg(Arg::with_name("binary").required(true))
-        )
+")
+            .arg(Arg::with_name("book").long("book").help("The Rust Programming Language book"))
+            .arg(Arg::with_name("std").long("std").help("Standard library API documentation"))
+            .group(ArgGroup::with_name("page").args(&["book", "std"])))
+        .subcommand(SubCommand::with_name("which")
+            .about("Report location of the currently active Rust tool.")
+            .arg(Arg::with_name("binary").required(true)))
 }
 
 fn install_args() -> Vec<Arg<'static, 'static>> {

--- a/src/rustup-cli/common.rs
+++ b/src/rustup-cli/common.rs
@@ -31,7 +31,9 @@ pub fn confirm(question: &str, default: bool) -> Result<bool> {
 }
 
 pub enum Confirm {
-    Yes, No, Advanced
+    Yes,
+    No,
+    Advanced,
 }
 
 pub fn confirm_advanced() -> Result<Confirm> {
@@ -44,7 +46,7 @@ pub fn confirm_advanced() -> Result<Confirm> {
     let input = try!(read_line());
 
     let r = match &*input {
-        "1"|"" => Confirm::Yes,
+        "1" | "" => Confirm::Yes,
         "2" => Confirm::Advanced,
         _ => Confirm::No,
     };
@@ -82,7 +84,7 @@ pub fn question_bool(question: &str, default: bool) -> Result<bool> {
         match &*input {
             "y" | "Y" | "yes" => Ok(true),
             "n" | "N" | "no" => Ok(false),
-            _ => Ok(default)
+            _ => Ok(default),
         }
     }
 
@@ -92,8 +94,7 @@ pub fn read_line() -> Result<String> {
     let stdin = std::io::stdin();
     let stdin = stdin.lock();
     let mut lines = stdin.lines();
-    lines.next().and_then(|l| l.ok()).ok_or(
-        "unable to read from stdin for confirmation".into())
+    lines.next().and_then(|l| l.ok()).ok_or("unable to read from stdin for confirmation".into())
 }
 
 pub fn set_globals(verbose: bool) -> Result<Cfg> {
@@ -103,7 +104,7 @@ pub fn set_globals(verbose: bool) -> Result<Cfg> {
     let download_tracker = RefCell::new(DownloadTracker::new());
 
     Ok(try!(Cfg::from_env(Arc::new(move |n: Notification| {
-       if download_tracker.borrow_mut().handle_notification(&n) {
+        if download_tracker.borrow_mut().handle_notification(&n) {
             return;
         }
 
@@ -127,12 +128,16 @@ pub fn set_globals(verbose: bool) -> Result<Cfg> {
 
 }
 
-pub fn show_channel_update(cfg: &Cfg, name: &str,
-                           updated: rustup::Result<UpdateStatus>) -> Result<()> {
+pub fn show_channel_update(cfg: &Cfg,
+                           name: &str,
+                           updated: rustup::Result<UpdateStatus>)
+                           -> Result<()> {
     show_channel_updates(cfg, vec![(name.to_string(), updated)])
 }
 
-fn show_channel_updates(cfg: &Cfg, toolchains: Vec<(String, rustup::Result<UpdateStatus>)>) -> Result<()> {
+fn show_channel_updates(cfg: &Cfg,
+                        toolchains: Vec<(String, rustup::Result<UpdateStatus>)>)
+                        -> Result<()> {
     let data = toolchains.into_iter().map(|(name, result)| {
         let ref toolchain = cfg.get_toolchain(&name, false).expect("");
         let version = rustc_version(toolchain);
@@ -223,7 +228,7 @@ pub fn rustc_version(toolchain: &Toolchain) -> String {
             cmd.arg("--version");
             toolchain.set_ldpath(&mut cmd);
 
-            let out= cmd.output().ok();
+            let out = cmd.output().ok();
             let out = out.into_iter().filter(|o| o.status.success()).next();
             let stdout = out.and_then(|o| String::from_utf8(o.stdout).ok());
             let line1 = stdout.and_then(|o| o.lines().next().map(|l| l.to_owned()));
@@ -327,9 +332,7 @@ pub fn list_overrides(cfg: &Cfg) -> Result<()> {
         println!("no overrides");
     } else {
         for (k, v) in overrides {
-            println!("{:<40}\t{:<20}",
-                     utils::format_path_for_display(&k),
-                     v)
+            println!("{:<40}\t{:<20}", utils::format_path_for_display(&k), v)
         }
     }
     Ok(())
@@ -337,7 +340,8 @@ pub fn list_overrides(cfg: &Cfg) -> Result<()> {
 
 
 pub fn version() -> &'static str {
-    concat!(env!("CARGO_PKG_VERSION"), include_str!(concat!(env!("OUT_DIR"), "/commit-info.txt")))
+    concat!(env!("CARGO_PKG_VERSION"),
+            include_str!(concat!(env!("OUT_DIR"), "/commit-info.txt")))
 }
 
 

--- a/src/rustup-cli/download_tracker.rs
+++ b/src/rustup-cli/download_tracker.rs
@@ -67,7 +67,7 @@ impl DownloadTracker {
                 self.download_finished();
                 true
             }
-            _ => false
+            _ => false,
         }
     }
 
@@ -123,8 +123,8 @@ impl DownloadTracker {
     fn display(&mut self) {
         let total_h = HumanReadable(self.total_downloaded as f64);
         let sum = self.downloaded_last_few_secs
-                      .iter()
-                      .fold(0., |a, &v| a + v as f64);
+            .iter()
+            .fold(0., |a, &v| a + v as f64);
         let len = self.downloaded_last_few_secs.len();
         let speed = if len > 0 {
             sum / len as f64
@@ -150,7 +150,9 @@ impl DownloadTracker {
             }
             None => {
                 let _ = write!(self.term.as_mut().unwrap(),
-                               "Total: {} Speed: {}/s", total_h, speed_h);
+                               "Total: {} Speed: {}/s",
+                               total_h,
+                               speed_h);
             }
         }
         // delete_line() doesn't seem to clear the line properly.
@@ -167,7 +169,8 @@ struct HumanReadable(f64);
 
 impl fmt::Display for HumanReadable {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if f.alternate() {  // repurposing the alternate mode for ETA
+        if f.alternate() {
+            // repurposing the alternate mode for ETA
             let sec = self.0;
 
             if sec.is_infinite() {

--- a/src/rustup-cli/help.rs
+++ b/src/rustup-cli/help.rs
@@ -1,5 +1,4 @@
-pub static RUSTUP_HELP: &'static str =
-r"
+pub static RUSTUP_HELP: &'static str = r"
 rustup installs The Rust Programming Language from the official
 release channels, enabling you to easily switch between stable, beta,
 and nightly compilers and keep them updated. It makes cross-compiling
@@ -8,8 +7,7 @@ simpler with binary builds of the standard library for common platforms.
 If you are new to Rust consider running `rustup doc --book`
 to learn Rust.";
 
-pub static SHOW_HELP: &'static str =
-r"
+pub static SHOW_HELP: &'static str = r"
 Shows the name of the active toolchain and the version of `rustc`.
 
 If the active toolchain has installed support for additional
@@ -18,8 +16,7 @@ compilation targets, then they are listed as well.
 If there are multiple toolchains installed then all installed
 toolchains are listed as well.";
 
-pub static UPDATE_HELP: &'static str =
-r"
+pub static UPDATE_HELP: &'static str = r"
 With no toolchain specified, the `update` command updates each of the
 installed toolchains from the official release channels, then updates
 rustup itself.
@@ -30,8 +27,7 @@ the same as `rustup toolchain install`.
 'toolchain' specifies a toolchain name, such as 'stable', 'nightly',
 or '1.8.0'. For more information see `rustup help toolchain`.";
 
-pub static TOOLCHAIN_INSTALL_HELP: &'static str =
-r"
+pub static TOOLCHAIN_INSTALL_HELP: &'static str = r"
 Installs a specific rust toolchain.
 
 The 'install' command is an alias for 'rustup update <toolchain>'.
@@ -39,13 +35,11 @@ The 'install' command is an alias for 'rustup update <toolchain>'.
 'toolchain' specifies a toolchain name, such as 'stable', 'nightly',
 or '1.8.0'. For more information see `rustup help toolchain`.";
 
-pub static DEFAULT_HELP: &'static str =
-r"
+pub static DEFAULT_HELP: &'static str = r"
 Sets the default toolchain to the one specified. If the toolchain is
 not already installed then it is installed first.";
 
-pub static TOOLCHAIN_HELP: &'static str =
-r"
+pub static TOOLCHAIN_HELP: &'static str = r"
 Many `rustup` commands deal with *toolchains*, a single installation
 of the Rust compiler. `rustup` supports multiple types of
 toolchains. The most basic track the official release channels:
@@ -80,8 +74,7 @@ inferred, so the above could be written:
 Toolchain names that don't name a channel instead can be used to name
 custom toolchains with the `rustup toolchain link` command.";
 
-pub static OVERRIDE_HELP: &'static str =
-r"
+pub static OVERRIDE_HELP: &'static str = r"
 Overrides configure rustup to use a specific toolchain when
 running in a specific directory.
 
@@ -102,15 +95,13 @@ Or a specific stable release:
 To see the active toolchain use `rustup show`. To remove the override
 and use the default toolchain again, `rustup override unset`.";
 
-pub static RUN_HELP: &'static str =
-r"
+pub static RUN_HELP: &'static str = r"
 Configures an environment to use the given toolchain and then runs
 the specified program. The command may be any program, not just
 rustc or cargo. This can be used for testing arbitrary toolchains
 without setting an override.";
 
-pub static DOC_HELP: &'static str =
-r"
+pub static DOC_HELP: &'static str = r"
 Opens the documentation for the currently active toolchain with the
 default browser.
 

--- a/src/rustup-cli/job.rs
+++ b/src/rustup-cli/job.rs
@@ -23,8 +23,7 @@ pub fn setup() {
 
 #[cfg(unix)]
 mod imp {
-    pub unsafe fn setup() {
-    }
+    pub unsafe fn setup() {}
 }
 
 #[cfg(windows)]
@@ -46,7 +45,7 @@ mod imp {
 
         let job = kernel32::CreateJobObjectW(0 as *mut _, 0 as *const _);
         if job.is_null() {
-            return
+            return;
         }
 
         // Indicate that when all handles to the job object are gone that all
@@ -55,15 +54,14 @@ mod imp {
         // our children will reside in the job once we spawn a process.
         let mut info: winapi::JOBOBJECT_EXTENDED_LIMIT_INFORMATION;
         info = mem::zeroed();
-        info.BasicLimitInformation.LimitFlags =
-            winapi::JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+        info.BasicLimitInformation.LimitFlags = winapi::JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
         let r = kernel32::SetInformationJobObject(job,
-                        winapi::JobObjectExtendedLimitInformation,
-                        &mut info as *mut _ as winapi::LPVOID,
-                        mem::size_of_val(&info) as winapi::DWORD);
+                                                  winapi::JobObjectExtendedLimitInformation,
+                                                  &mut info as *mut _ as winapi::LPVOID,
+                                                  mem::size_of_val(&info) as winapi::DWORD);
         if r == 0 {
             kernel32::CloseHandle(job);
-            return
+            return;
         }
 
         // Assign our process to this job object, meaning that our children will
@@ -72,7 +70,7 @@ mod imp {
         let r = kernel32::AssignProcessToJobObject(job, me);
         if r == 0 {
             kernel32::CloseHandle(job);
-            return
+            return;
         }
 
         // Intentionally leak the `job` handle here. We've got the only

--- a/src/rustup-cli/main.rs
+++ b/src/rustup-cli/main.rs
@@ -59,8 +59,10 @@ fn main() {
 
 fn run_multirust() -> Result<()> {
     // Guard against infinite recursion
-    let recursion_count = env::var("RUST_RECURSION_COUNT").ok()
-        .and_then(|s| s.parse().ok()).unwrap_or(0);
+    let recursion_count = env::var("RUST_RECURSION_COUNT")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
     if recursion_count > 5 {
         return Err(ErrorKind::InfiniteRecursion.into());
     }
@@ -75,14 +77,9 @@ fn run_multirust() -> Result<()> {
         .and_then(|a| a.file_stem())
         .and_then(|a| a.to_str());
     match name {
-        Some("rustup") => {
-            rustup_mode::main()
-        }
-        Some("multirust") => {
-            multirust_mode::main()
-        }
-        Some(n) if n.starts_with("multirust-setup")||
-                   n.starts_with("rustup-setup") ||
+        Some("rustup") => rustup_mode::main(),
+        Some("multirust") => multirust_mode::main(),
+        Some(n) if n.starts_with("multirust-setup") || n.starts_with("rustup-setup") ||
                    n.starts_with("rustup-init") => {
             // NB: The above check is only for the prefix of the file
             // name. Browsers rename duplicates to
@@ -113,9 +110,7 @@ fn run_multirust() -> Result<()> {
                 self_update::install(true, false, opts)
             }
         }
-        Some(_) => {
-            proxy_mode::main()
-        }
+        Some(_) => proxy_mode::main(),
         None => {
             // Weird case. No arg0, or it's unparsable.
             Err(ErrorKind::NoExeName.into())
@@ -142,7 +137,7 @@ fn make_environment_compatible() {
                 env::set_var(rvar, mval);
                 warn!("environment variable {} is deprecated. Use {}.", mvar, rvar);
             }
-            _ => ()
+            _ => (),
         }
     }
 }
@@ -158,13 +153,23 @@ fn fix_windows_reg_key() {
     let root = RegKey::predef(HKEY_CURRENT_USER);
     let env = root.open_subkey_with_flags("Environment", KEY_READ | KEY_WRITE);
 
-    let env = if let Ok(e) = env { e } else { return };
+    let env = if let Ok(e) = env {
+        e
+    } else {
+        return;
+    };
 
     let path = env.get_raw_value("PATH");
 
-    let mut path = if let Ok(p) = path { p } else { return };
+    let mut path = if let Ok(p) = path {
+        p
+    } else {
+        return;
+    };
 
-    if path.vtype == RegType::REG_EXPAND_SZ { return }
+    if path.vtype == RegType::REG_EXPAND_SZ {
+        return;
+    }
 
     path.vtype = RegType::REG_EXPAND_SZ;
 
@@ -172,4 +177,4 @@ fn fix_windows_reg_key() {
 }
 
 #[cfg(not(windows))]
-fn fix_windows_reg_key() { }
+fn fix_windows_reg_key() {}

--- a/src/rustup-cli/multirust_mode.rs
+++ b/src/rustup-cli/multirust_mode.rs
@@ -1,7 +1,6 @@
 use clap::ArgMatches;
 use cli;
-use common::{self, confirm, set_globals,
-             show_channel_update, show_tool_versions,
+use common::{self, confirm, set_globals, show_channel_update, show_tool_versions,
              update_all_channels};
 use errors::*;
 use rustup::{Cfg, Notification, command, utils, Toolchain};
@@ -18,7 +17,8 @@ pub fn main() -> Result<()> {
 
     let need_metadata = try!(command_requires_metadata());
     if need_metadata {
-        let cfg = try!(Cfg::from_env(Arc::new(move |_: Notification| { })));
+        let cfg = try!(Cfg::from_env(Arc::new(move |_: Notification| {
+        })));
         try!(cfg.check_metadata_version());
     }
 
@@ -33,7 +33,8 @@ pub fn main() -> Result<()> {
     // it interferes with the fragile self-deletion code.
     maybe_setup_winjob(&app_matches);
 
-    warn!("'multirust' is being renamed to 'rustup'. this command is deprecated. use 'rustup' instead");
+    warn!("'multirust' is being renamed to 'rustup'. this command is deprecated. use 'rustup' \
+           instead");
 
     match app_matches.subcommand() {
         ("update", Some(m)) => update(&cfg, m),
@@ -61,15 +62,13 @@ pub fn main() -> Result<()> {
         }
         ("which", Some(m)) => which(&cfg, m),
         ("doc", Some(m)) => doc(&cfg, m),
-        _ => {
-            unreachable!()
-        }
+        _ => unreachable!(),
     }
 }
 
 fn maybe_setup_winjob(m: &ArgMatches) {
     match m.subcommand() {
-        ("self", _) => { }
+        ("self", _) => {}
         (_, _) => {
             job::setup();
         }
@@ -99,16 +98,12 @@ fn command_requires_metadata() -> Result<bool> {
     match (arg1, arg2) {
         (Some("upgrade-data"), _) |
         (Some("delete-data"), _) |
-        (Some("self"), Some("install")) => {
-            Ok(false)
-        }
+        (Some("self"), Some("install")) => Ok(false),
         (None, None) => {
             // Running multirust in its self-install mode
             Ok(false)
         }
-        (_, _) => {
-            Ok(true)
-        }
+        (_, _) => Ok(true),
     }
 }
 
@@ -233,7 +228,7 @@ fn which(cfg: &Cfg, m: &ArgMatches) -> Result<()> {
     let binary = m.value_of("binary").unwrap();
 
     let binary_path = try!(cfg.which_binary(&try!(utils::current_dir()), binary))
-                          .expect("binary not found");
+        .expect("binary not found");
 
     try!(utils::assert_is_file(&binary_path));
 
@@ -242,8 +237,7 @@ fn which(cfg: &Cfg, m: &ArgMatches) -> Result<()> {
 }
 
 fn delete_data(cfg: &Cfg, m: &ArgMatches) -> Result<()> {
-    let msg =
-r"
+    let msg = r"
 This will delete all toolchains, overrides, aliases, and other
 multirust data associated with this user.
 
@@ -264,11 +258,11 @@ Continue? (y/N)";
 fn remove_override(cfg: &Cfg, m: &ArgMatches) -> Result<()> {
     let cwd = try!(utils::current_dir());
     let ref path = m.value_of("override")
-        .map(|p| PathBuf::from(p)).unwrap_or(cwd);
+        .map(|p| PathBuf::from(p))
+        .unwrap_or(cwd);
 
-    if try!(cfg.settings_file.with_mut(|s| {
-        Ok(s.remove_override(path, cfg.notify_handler.as_ref()))
-    })) {
+    if try!(cfg.settings_file
+        .with_mut(|s| Ok(s.remove_override(path, cfg.notify_handler.as_ref())))) {
         info!("override toolchain for '{}' removed", path.display());
     } else {
         info!("no override toolchain for '{}'", path.display());

--- a/src/rustup-cli/proxy_mode.rs
+++ b/src/rustup-cli/proxy_mode.rs
@@ -1,5 +1,5 @@
 use common::set_globals;
-use rustup::{Cfg};
+use rustup::Cfg;
 use errors::*;
 use rustup_utils::utils;
 use rustup::command::run_command_for_dir;
@@ -31,4 +31,3 @@ fn direct_proxy(cfg: &Cfg, arg0: &str) -> Result<()> {
 
     Ok(try!(run_command_for_dir(cmd, &args, &cfg)))
 }
-

--- a/src/rustup-cli/rustup_mode.rs
+++ b/src/rustup-cli/rustup_mode.rs
@@ -21,7 +21,7 @@ pub fn main() -> Result<()> {
     let ref cfg = try!(common::set_globals(verbose));
 
     if try!(maybe_upgrade_data(cfg, matches)) {
-        return Ok(())
+        return Ok(());
     }
 
     try!(cfg.check_metadata_version());
@@ -63,7 +63,7 @@ pub fn main() -> Result<()> {
                 // Synonyms
                 ("add", Some(m)) => try!(override_add(cfg, m)),
                 ("remove", Some(_)) => try!(override_remove(cfg)),
-                (_ ,_) => unreachable!(),
+                (_, _) => unreachable!(),
             }
         }
         ("run", Some(m)) => try!(run(cfg, m)),
@@ -73,7 +73,7 @@ pub fn main() -> Result<()> {
             match c.subcommand() {
                 ("update", Some(_)) => try!(self_update::update()),
                 ("uninstall", Some(m)) => try!(self_uninstall(m)),
-                (_ ,_) => unreachable!(),
+                (_, _) => unreachable!(),
             }
         }
         ("telemetry", Some(c)) => {
@@ -120,8 +120,7 @@ pub fn cli() -> App<'static, 'static> {
         .subcommand(SubCommand::with_name("update")
             .about("Update Rust toolchains")
             .after_help(UPDATE_HELP)
-            .arg(Arg::with_name("toolchain")
-                .required(false))
+            .arg(Arg::with_name("toolchain").required(false))
             .arg(Arg::with_name("no-self-update")
                 .help("Don't perform self update when running the `rustup` command")
                 .long("no-self-update")
@@ -130,30 +129,24 @@ pub fn cli() -> App<'static, 'static> {
         .subcommand(SubCommand::with_name("default")
             .about("Set the default toolchain")
             .after_help(DEFAULT_HELP)
-            .arg(Arg::with_name("toolchain")
-                .required(true)))
+            .arg(Arg::with_name("toolchain").required(true)))
         .subcommand(SubCommand::with_name("toolchain")
             .about("Modify or query the installed toolchains")
             .after_help(TOOLCHAIN_HELP)
             .setting(AppSettings::VersionlessSubcommands)
             .setting(AppSettings::DeriveDisplayOrder)
             .setting(AppSettings::SubcommandRequiredElseHelp)
-            .subcommand(SubCommand::with_name("list")
-                .about("List installed toolchains"))
+            .subcommand(SubCommand::with_name("list").about("List installed toolchains"))
             .subcommand(SubCommand::with_name("install")
                 .about("Install or update a given toolchain")
-                .arg(Arg::with_name("toolchain")
-                .required(true)))
+                .arg(Arg::with_name("toolchain").required(true)))
             .subcommand(SubCommand::with_name("uninstall")
                 .about("Uninstall a toolchain")
-                .arg(Arg::with_name("toolchain")
-                     .required(true)))
+                .arg(Arg::with_name("toolchain").required(true)))
             .subcommand(SubCommand::with_name("link")
                 .about("Create a custom toolchain by symlinking to a directory")
-                .arg(Arg::with_name("toolchain")
-                    .required(true))
-                .arg(Arg::with_name("path")
-                    .required(true)))
+                .arg(Arg::with_name("toolchain").required(true))
+                .arg(Arg::with_name("path").required(true)))
             .subcommand(SubCommand::with_name("update")
                 .setting(AppSettings::Hidden) // synonym for 'install'
                 .arg(Arg::with_name("toolchain")
@@ -178,15 +171,13 @@ pub fn cli() -> App<'static, 'static> {
                     .takes_value(true)))
             .subcommand(SubCommand::with_name("add")
                 .about("Add a target to a Rust toolchain")
-                .arg(Arg::with_name("target")
-                    .required(true))
+                .arg(Arg::with_name("target").required(true))
                 .arg(Arg::with_name("toolchain")
                     .long("toolchain")
                     .takes_value(true)))
             .subcommand(SubCommand::with_name("remove")
                 .about("Remove a target  from a Rust toolchain")
-                .arg(Arg::with_name("target")
-                    .required(true))
+                .arg(Arg::with_name("target").required(true))
                 .arg(Arg::with_name("toolchain")
                     .long("toolchain")
                     .takes_value(true)))
@@ -210,12 +201,10 @@ pub fn cli() -> App<'static, 'static> {
             .setting(AppSettings::VersionlessSubcommands)
             .setting(AppSettings::DeriveDisplayOrder)
             .setting(AppSettings::SubcommandRequiredElseHelp)
-            .subcommand(SubCommand::with_name("list")
-                .about("List directory toolchain overrides"))
+            .subcommand(SubCommand::with_name("list").about("List directory toolchain overrides"))
             .subcommand(SubCommand::with_name("set")
                 .about("Set the override toolchain for a directory")
-                .arg(Arg::with_name("toolchain")
-                     .required(true)))
+                .arg(Arg::with_name("toolchain").required(true)))
             .subcommand(SubCommand::with_name("unset")
                 .about("Remove the override toolchain for a directory"))
             .subcommand(SubCommand::with_name("add")
@@ -229,25 +218,23 @@ pub fn cli() -> App<'static, 'static> {
             .about("Run a command with an environment configured for a given toolchain")
             .after_help(RUN_HELP)
             .setting(AppSettings::TrailingVarArg)
-            .arg(Arg::with_name("toolchain")
-                .required(true))
+            .arg(Arg::with_name("toolchain").required(true))
             .arg(Arg::with_name("command")
-                .required(true).multiple(true)))
+                .required(true)
+                .multiple(true)))
         .subcommand(SubCommand::with_name("which")
             .about("Display which binary will be run for a given command")
-            .arg(Arg::with_name("command")
-                .required(true)))
+            .arg(Arg::with_name("command").required(true)))
         .subcommand(SubCommand::with_name("doc")
             .about("Open the documentation for the current toolchain")
             .after_help(DOC_HELP)
             .arg(Arg::with_name("book")
-                 .long("book")
-                 .help("The Rust Programming Language book"))
+                .long("book")
+                .help("The Rust Programming Language book"))
             .arg(Arg::with_name("std")
-                 .long("std")
-                 .help("Standard library API documentation"))
-            .group(ArgGroup::with_name("page")
-                 .args(&["book", "std"])))
+                .long("std")
+                .help("Standard library API documentation"))
+            .group(ArgGroup::with_name("page").args(&["book", "std"])))
         .subcommand(SubCommand::with_name("self")
             .about("Modify the rustup installation")
             .setting(AppSettings::VersionlessSubcommands)
@@ -257,8 +244,7 @@ pub fn cli() -> App<'static, 'static> {
                 .about("Download and install updates to rustup"))
             .subcommand(SubCommand::with_name("uninstall")
                 .about("Uninstall rustup.")
-                .arg(Arg::with_name("no-prompt")
-                     .short("y")))
+                .arg(Arg::with_name("no-prompt").short("y")))
             .subcommand(SubCommand::with_name("upgrade-data")
                 .about("Upgrade the internal data format.")))
         .subcommand(SubCommand::with_name("telemetry")
@@ -266,19 +252,15 @@ pub fn cli() -> App<'static, 'static> {
             .setting(AppSettings::VersionlessSubcommands)
             .setting(AppSettings::DeriveDisplayOrder)
             .setting(AppSettings::SubcommandRequiredElseHelp)
-            .subcommand(SubCommand::with_name("enable")
-                            .about("Enable rustup telemetry"))
-            .subcommand(SubCommand::with_name("disable")
-                            .about("Disable rustup telemetry"))
-            .subcommand(SubCommand::with_name("analyze")
-                            .about("Analyze stored telemetry")))
+            .subcommand(SubCommand::with_name("enable").about("Enable rustup telemetry"))
+            .subcommand(SubCommand::with_name("disable").about("Disable rustup telemetry"))
+            .subcommand(SubCommand::with_name("analyze").about("Analyze stored telemetry")))
         .subcommand(SubCommand::with_name("set")
             .about("Alter rustup settings")
             .setting(AppSettings::SubcommandRequiredElseHelp)
             .subcommand(SubCommand::with_name("default-host")
                 .about("The triple used to identify toolchains when not specified")
-                .arg(Arg::with_name("host_triple")
-                    .required(true))))
+                .arg(Arg::with_name("host_triple").required(true))))
 }
 
 fn maybe_upgrade_data(cfg: &Cfg, m: &ArgMatches) -> Result<bool> {
@@ -292,47 +274,52 @@ fn maybe_upgrade_data(cfg: &Cfg, m: &ArgMatches) -> Result<bool> {
                 _ => Ok(false),
             }
         }
-        _ => Ok(false)
+        _ => Ok(false),
     }
 }
 
 fn update_bare_triple_check(cfg: &Cfg, name: &str) -> Result<()> {
     if let Some(triple) = PartialTargetTriple::from_str(name) {
-	warn!("(partial) target triple specified instead of toolchain name");
+        warn!("(partial) target triple specified instead of toolchain name");
         let installed_toolchains = try!(cfg.list_toolchains());
         let default = try!(cfg.find_default());
         let default_name = default.map(|t| t.name().to_string())
-                           .unwrap_or("".into());
+            .unwrap_or("".into());
         let mut candidates = vec![];
         for t in installed_toolchains {
             if t == default_name {
-		continue;
-	    }
+                continue;
+            }
             if let Ok(desc) = PartialToolchainDesc::from_str(&t) {
                 fn triple_comp_eq(given: &String, from_desc: Option<&String>) -> bool {
                     from_desc.map_or(false, |s| *s == *given)
                 }
 
-                let triple_matches =
-                    triple.arch.as_ref().map_or(true, |s| triple_comp_eq(s, desc.target.arch.as_ref()))
-                    && triple.os.as_ref().map_or(true, |s| triple_comp_eq(s, desc.target.os.as_ref()))
-                    && triple.env.as_ref().map_or(true, |s| triple_comp_eq(s, desc.target.env.as_ref()));
+                let triple_matches = triple.arch
+                    .as_ref()
+                    .map_or(true, |s| triple_comp_eq(s, desc.target.arch.as_ref())) &&
+                                     triple.os
+                    .as_ref()
+                    .map_or(true, |s| triple_comp_eq(s, desc.target.os.as_ref())) &&
+                                     triple.env
+                    .as_ref()
+                    .map_or(true, |s| triple_comp_eq(s, desc.target.env.as_ref()));
                 if triple_matches {
                     candidates.push(t);
                 }
             }
         }
-	match candidates.len() {
-	    0 => err!("no candidate toolchains found"),
-	    1 => println!("\nyou may use the following toolchain: {}\n", candidates[0]),
-	    _ => {
-		println!("\nyou may use one of the following toolchains:");
-		for n in candidates.iter() {
-		    println!("{}", n);
-		}
-		println!("");
-	    }
-	}
+        match candidates.len() {
+            0 => err!("no candidate toolchains found"),
+            1 => println!("\nyou may use the following toolchain: {}\n", candidates[0]),
+            _ => {
+                println!("\nyou may use one of the following toolchains:");
+                for n in candidates.iter() {
+                    println!("{}", n);
+                }
+                println!("");
+            }
+        }
         return Err(ErrorKind::ToolchainNotInstalled(name.to_string()).into());
     }
     Ok(())
@@ -343,18 +330,20 @@ fn default_bare_triple_check(cfg: &Cfg, name: &str) -> Result<()> {
         warn!("(partial) target triple specified instead of toolchain name");
         let default = try!(cfg.find_default());
         let default_name = default.map(|t| t.name().to_string())
-                           .unwrap_or("".into());
-	if let Ok(mut desc) = PartialToolchainDesc::from_str(&default_name) {
-	    desc.target = triple;
-	    let maybe_toolchain = format!("{}", desc);
-	    let ref toolchain = try!(cfg.get_toolchain(maybe_toolchain.as_ref(), false));
-	    if toolchain.name() == default_name {
-		warn!("(partial) triple '{}' resolves to a toolchain that is already default", name);
-	    } else {
-		println!("\nyou may use the following toolchain: {}\n", toolchain.name());
-	    }
-	    return Err(ErrorKind::ToolchainNotInstalled(name.to_string()).into());
-	}
+            .unwrap_or("".into());
+        if let Ok(mut desc) = PartialToolchainDesc::from_str(&default_name) {
+            desc.target = triple;
+            let maybe_toolchain = format!("{}", desc);
+            let ref toolchain = try!(cfg.get_toolchain(maybe_toolchain.as_ref(), false));
+            if toolchain.name() == default_name {
+                warn!("(partial) triple '{}' resolves to a toolchain that is already default",
+                      name);
+            } else {
+                println!("\nyou may use the following toolchain: {}\n",
+                         toolchain.name());
+            }
+            return Err(ErrorKind::ToolchainNotInstalled(name.to_string()).into());
+        }
     }
     Ok(())
 }
@@ -419,7 +408,7 @@ fn which(cfg: &Cfg, m: &ArgMatches) -> Result<()> {
     let binary = m.value_of("command").expect("");
 
     let binary_path = try!(cfg.which_binary(&try!(utils::current_dir()), binary))
-                          .expect("binary not found");
+        .expect("binary not found");
 
     try!(utils::assert_is_file(&binary_path));
 
@@ -457,17 +446,18 @@ fn show(cfg: &Cfg) -> Result<()> {
     let show_active_toolchain = true;
 
     // Only need to display headers if we have multiple sections
-    let show_headers = [
-        show_installed_toolchains,
-        show_active_targets,
-        show_active_toolchain
-    ].iter().filter(|x| **x).count() > 1;
+    let show_headers = [show_installed_toolchains, show_active_targets, show_active_toolchain]
+        .iter()
+        .filter(|x| **x)
+        .count() > 1;
 
     if show_installed_toolchains {
-        if show_headers { print_header("installed toolchains") }
+        if show_headers {
+            print_header("installed toolchains")
+        }
         let default = try!(cfg.find_default());
         let default_name = default.map(|t| t.name().to_string())
-                           .unwrap_or("".into());
+            .unwrap_or("".into());
         for t in installed_toolchains {
             if default_name == t {
                 println!("{} (default)", t);
@@ -475,7 +465,9 @@ fn show(cfg: &Cfg) -> Result<()> {
                 println!("{}", t);
             }
         }
-        if show_headers { println!("") };
+        if show_headers {
+            println!("")
+        };
     }
 
     if show_active_targets {
@@ -485,11 +477,15 @@ fn show(cfg: &Cfg) -> Result<()> {
         for t in active_targets {
             println!("{}", t.component.target);
         }
-        if show_headers { println!("") };
+        if show_headers {
+            println!("")
+        };
     }
 
     if show_active_toolchain {
-        if show_headers { print_header("active toolchain") }
+        if show_headers {
+            print_header("active toolchain")
+        }
 
         match active_toolchain {
             Some((ref toolchain, Some(ref reason))) => {
@@ -505,7 +501,9 @@ fn show(cfg: &Cfg) -> Result<()> {
             }
         }
 
-        if show_headers { println!("") };
+        if show_headers {
+            println!("")
+        };
     }
 
     fn print_header(s: &str) {
@@ -601,9 +599,8 @@ fn override_add(cfg: &Cfg, m: &ArgMatches) -> Result<()> {
 fn override_remove(cfg: &Cfg) -> Result<()> {
     let ref path = try!(utils::current_dir());
 
-    if try!(cfg.settings_file.with_mut(|s| {
-        Ok(s.remove_override(path, cfg.notify_handler.as_ref()))
-    })) {
+    if try!(cfg.settings_file
+        .with_mut(|s| Ok(s.remove_override(path, cfg.notify_handler.as_ref())))) {
         info!("override toolchain for '{}' removed", path.display());
     } else {
         info!("no override toolchain for '{}'", path.display());

--- a/src/rustup-cli/self_update.rs
+++ b/src/rustup-cli/self_update.rs
@@ -163,11 +163,10 @@ This will uninstall all Rust toolchains and data, and remove
     }
 }
 
-static TOOLS: &'static [&'static str]
-    = &["rustup", "rustc", "rustdoc", "cargo", "rust-lldb", "rust-gdb"];
+static TOOLS: &'static [&'static str] =
+    &["rustup", "rustc", "rustdoc", "cargo", "rust-lldb", "rust-gdb"];
 
-static UPDATE_ROOT: &'static str
-    = "https://static.rust-lang.org/rustup/dist";
+static UPDATE_ROOT: &'static str = "https://static.rust-lang.org/rustup/dist";
 
 /// CARGO_HOME suitable for display, possibly with $HOME
 /// substituted for the directory prefix
@@ -186,8 +185,7 @@ fn canonical_cargo_home() -> Result<String> {
 /// Installing is a simple matter of coping the running binary to
 /// CARGO_HOME/bin, hardlinking the various Rust tools to it,
 /// and and adding CARGO_HOME/bin to PATH.
-pub fn install(no_prompt: bool, verbose: bool,
-               mut opts: InstallOpts) -> Result<()> {
+pub fn install(no_prompt: bool, verbose: bool, mut opts: InstallOpts) -> Result<()> {
 
     try!(do_pre_install_sanity_checks());
 
@@ -202,10 +200,10 @@ pub fn install(no_prompt: bool, verbose: bool,
                 Confirm::No => {
                     info!("aborting installation");
                     return Ok(());
-                },
+                }
                 Confirm::Yes => {
                     break;
-                },
+                }
                 Confirm::Advanced => {
                     opts = try!(customize_install(opts));
                 }
@@ -213,24 +211,23 @@ pub fn install(no_prompt: bool, verbose: bool,
         }
     }
 
-    let install_res: Result<()> = (|| {
-        try!(cleanup_legacy());
-        try!(install_bins());
-        if !opts.no_modify_path {
-            try!(do_add_to_path(&get_add_path_methods()));
-        }
-        try!(maybe_install_rust(&opts.default_toolchain, &opts.default_host_triple, verbose));
+    let install_res: Result<()> =
+        (|| {
+            try!(cleanup_legacy());
+            try!(install_bins());
+            if !opts.no_modify_path {
+                try!(do_add_to_path(&get_add_path_methods()));
+            }
+            try!(maybe_install_rust(&opts.default_toolchain, &opts.default_host_triple, verbose));
 
-        if cfg!(unix) {
-            let ref env_file = try!(utils::cargo_home()).join("env");
-            let ref env_str = format!(
-                "{}\n",
-                try!(shell_export_string()));
-            try!(utils::write_file("env", env_file, env_str));
-        }
+            if cfg!(unix) {
+                let ref env_file = try!(utils::cargo_home()).join("env");
+                let ref env_str = format!("{}\n", try!(shell_export_string()));
+                try!(utils::write_file("env", env_file, env_str));
+            }
 
-        Ok(())
-    })();
+            Ok(())
+        })();
 
 
     if let Err(ref e) = install_res {
@@ -254,8 +251,7 @@ pub fn install(no_prompt: bool, verbose: bool,
         let msg = if !opts.no_modify_path {
             if cfg!(unix) {
                 let cargo_home = try!(canonical_cargo_home());
-                format!(post_install_msg_unix!(),
-                         cargo_home = cargo_home)
+                format!(post_install_msg_unix!(), cargo_home = cargo_home)
             } else {
                 format!(post_install_msg_win!())
             }
@@ -263,7 +259,7 @@ pub fn install(no_prompt: bool, verbose: bool,
             if cfg!(unix) {
                 let cargo_home = try!(canonical_cargo_home());
                 format!(post_install_msg_unix_no_modify_path!(),
-                         cargo_home = cargo_home)
+                        cargo_home = cargo_home)
             } else {
                 format!(post_install_msg_win_no_modify_path!())
             }
@@ -285,28 +281,21 @@ pub fn install(no_prompt: bool, verbose: bool,
 
 fn do_pre_install_sanity_checks() -> Result<()> {
 
-    let multirust_manifest_path
-        = PathBuf::from("/usr/local/lib/rustlib/manifest-multirust");
-    let rustc_manifest_path
-        = PathBuf::from("/usr/local/lib/rustlib/manifest-rustc");
-    let uninstaller_path
-        = PathBuf::from("/usr/local/lib/rustlib/uninstall.sh");
-    let multirust_meta_path
-        = env::home_dir().map(|d| d.join(".multirust"));
-    let multirust_version_path
-        = multirust_meta_path.as_ref().map(|p| p.join("version"));
-    let rustup_sh_path
-        = env::home_dir().map(|d| d.join(".rustup"));
+    let multirust_manifest_path = PathBuf::from("/usr/local/lib/rustlib/manifest-multirust");
+    let rustc_manifest_path = PathBuf::from("/usr/local/lib/rustlib/manifest-rustc");
+    let uninstaller_path = PathBuf::from("/usr/local/lib/rustlib/uninstall.sh");
+    let multirust_meta_path = env::home_dir().map(|d| d.join(".multirust"));
+    let multirust_version_path = multirust_meta_path.as_ref().map(|p| p.join("version"));
+    let rustup_sh_path = env::home_dir().map(|d| d.join(".rustup"));
     let rustup_sh_version_path = rustup_sh_path.as_ref().map(|p| p.join("rustup-version"));
 
-    let multirust_exists =
-        multirust_manifest_path.exists() && uninstaller_path.exists();
-    let rustc_exists =
-        rustc_manifest_path.exists() && uninstaller_path.exists();
-    let rustup_sh_exists =
-        rustup_sh_version_path.map(|p| p.exists()) == Some(true);
-    let old_multirust_meta_exists = if let Some(ref multirust_version_path) = multirust_version_path {
-        multirust_version_path.exists() && {
+    let multirust_exists = multirust_manifest_path.exists() && uninstaller_path.exists();
+    let rustc_exists = rustc_manifest_path.exists() && uninstaller_path.exists();
+    let rustup_sh_exists = rustup_sh_version_path.map(|p| p.exists()) == Some(true);
+    let old_multirust_meta_exists = if let Some(ref multirust_version_path) =
+                                           multirust_version_path {
+        multirust_version_path.exists() &&
+        {
             let version = utils::read_file("old-multirust", &multirust_version_path);
             let version = version.unwrap_or(String::new());
             let version = version.parse().unwrap_or(0);
@@ -322,35 +311,41 @@ fn do_pre_install_sanity_checks() -> Result<()> {
         (true, false) => {
             warn!("it looks like you have an existing installation of multirust");
             warn!("rustup cannot be installed alongside multirust");
-            warn!("run `{}` as root to uninstall multirust before installing rustup", uninstaller_path.display());
+            warn!("run `{}` as root to uninstall multirust before installing rustup",
+                  uninstaller_path.display());
             return Err("cannot install while multirust is installed".into());
         }
         (false, true) => {
             warn!("it looks like you have existing multirust metadata");
             warn!("rustup cannot be installed alongside multirust");
-            warn!("delete `{}` before installing rustup", multirust_meta_path.expect("").display());
+            warn!("delete `{}` before installing rustup",
+                  multirust_meta_path.expect("").display());
             return Err("cannot install while multirust is installed".into());
         }
         (true, true) => {
             warn!("it looks like you have an existing installation of multirust");
             warn!("rustup cannot be installed alongside multirust");
-            warn!("run `{}` as root and delete `{}` before installing rustup", uninstaller_path.display(), multirust_meta_path.expect("").display());
+            warn!("run `{}` as root and delete `{}` before installing rustup",
+                  uninstaller_path.display(),
+                  multirust_meta_path.expect("").display());
             return Err("cannot install while multirust is installed".into());
         }
-        (false, false) => ()
+        (false, false) => (),
     }
 
     if rustc_exists {
         warn!("it looks like you have an existing installation of Rust");
         warn!("rustup cannot be installed alongside Rust. Please uninstall first");
-        warn!("run `{}` as root to uninstall Rust", uninstaller_path.display());
+        warn!("run `{}` as root to uninstall Rust",
+              uninstaller_path.display());
         return Err("cannot install while Rust is installed".into());
     }
 
     if rustup_sh_exists {
         warn!("it looks like you have existing rustup.sh metadata");
         warn!("rustup cannot be installed while rustup.sh metadata exists");
-        warn!("delete `{}` to remove rustup.sh", rustup_sh_path.expect("").display());
+        warn!("delete `{}` to remove rustup.sh",
+              rustup_sh_path.expect("").display());
         return Err("cannot install while rustup.sh is installed".into());
     }
 
@@ -371,7 +366,8 @@ fn pre_install_msg(no_modify_path: bool) -> Result<String> {
                     } else {
                         None
                     }
-                }).collect::<Vec<_>>();
+                })
+                .collect::<Vec<_>>();
             assert!(rcfiles.len() == 1); // Only modifying .profile
             Ok(format!(pre_install_msg_unix!(),
                        cargo_home_bin = cargo_home_bin.display(),
@@ -387,39 +383,37 @@ fn pre_install_msg(no_modify_path: bool) -> Result<String> {
 }
 
 fn current_install_opts(opts: &InstallOpts) -> String {
-    format!(
-        r"Current installation options:
+    format!(r"Current installation options:
 
 - ` `default host triple: `{}`
 - `   `default toolchain: `{}`
 - modify PATH variable: `{}`
 ",
-        opts.default_host_triple,
-        opts.default_toolchain,
-        if !opts.no_modify_path { "yes" } else { "no" }
-    )
+            opts.default_host_triple,
+            opts.default_toolchain,
+            if !opts.no_modify_path {
+                "yes"
+            } else {
+                "no"
+            })
 }
 
 // Interactive editing of the install options
 fn customize_install(mut opts: InstallOpts) -> Result<InstallOpts> {
 
-    println!(
-        "I'm going to ask you the value of each these installation options.\n\
-         You may simply press the Enter key to leave unchanged.");
+    println!("I'm going to ask you the value of each these installation options.\nYou may simply \
+              press the Enter key to leave unchanged.");
 
     println!("");
 
-    opts.default_host_triple = try!(common::question_str(
-        "Default host triple?",
-        &opts.default_host_triple));
+    opts.default_host_triple = try!(common::question_str("Default host triple?",
+                                                         &opts.default_host_triple));
 
-    opts.default_toolchain = try!(common::question_str(
-        "Default toolchain? (stable/beta/nightly)",
-        &opts.default_toolchain));
+    opts.default_toolchain = try!(common::question_str("Default toolchain? (stable/beta/nightly)",
+                                                       &opts.default_toolchain));
 
-    opts.no_modify_path = !try!(common::question_bool(
-        "Modify PATH variable? (y/n)",
-        !opts.no_modify_path));
+    opts.no_modify_path = !try!(common::question_bool("Modify PATH variable? (y/n)",
+                                                      !opts.no_modify_path));
 
     Ok(opts)
 }
@@ -447,9 +441,7 @@ fn cleanup_legacy() -> Result<()> {
 
     #[cfg(windows)]
     fn legacy_multirust_home_dir() -> Result<PathBuf> {
-        use rustup_utils::raw::windows::{
-            get_special_folder, FOLDERID_LocalAppData
-        };
+        use rustup_utils::raw::windows::{get_special_folder, FOLDERID_LocalAppData};
 
         Ok(get_special_folder(&FOLDERID_LocalAppData).unwrap_or(PathBuf::from(".")))
     }
@@ -635,9 +627,8 @@ fn delete_multirust_and_cargo_home() -> Result<()> {
     let numbah: u32 = rand::random();
     let gc_exe = work_path.join(&format!("multirust-gc-{:x}.exe", numbah));
 
-    use winapi::{FILE_SHARE_DELETE, FILE_SHARE_READ,
-                 INVALID_HANDLE_VALUE, FILE_FLAG_DELETE_ON_CLOSE,
-                 DWORD, SECURITY_ATTRIBUTES, OPEN_EXISTING,
+    use winapi::{FILE_SHARE_DELETE, FILE_SHARE_READ, INVALID_HANDLE_VALUE,
+                 FILE_FLAG_DELETE_ON_CLOSE, DWORD, SECURITY_ATTRIBUTES, OPEN_EXISTING,
                  GENERIC_READ};
     use kernel32::{CreateFileW, CloseHandle};
     use std::os::windows::ffi::OsStrExt;
@@ -672,10 +663,13 @@ fn delete_multirust_and_cargo_home() -> Result<()> {
             return Err(err).chain_err(|| ErrorKind::WindowsUninstallMadness);
         }
 
-        let _g = scopeguard::guard(gc_handle, |h| { let _ = CloseHandle(*h); });
+        let _g = scopeguard::guard(gc_handle, |h| {
+            let _ = CloseHandle(*h);
+        });
 
-        try!(Command::new(gc_exe).spawn()
-             .chain_err(|| ErrorKind::WindowsUninstallMadness));
+        try!(Command::new(gc_exe)
+            .spawn()
+            .chain_err(|| ErrorKind::WindowsUninstallMadness));
 
         // The catch 22 article says we must sleep here to give
         // Windows a chance to bump the processes file reference
@@ -705,22 +699,21 @@ pub fn complete_windows_uninstall() -> Result<()> {
     let rm_gc_exe = OsStr::new("net");
 
     try!(Command::new(rm_gc_exe)
-         .stdin(Stdio::null())
-         .stdout(Stdio::null())
-         .stderr(Stdio::null())
-         .spawn()
-         .chain_err(|| ErrorKind::WindowsUninstallMadness));
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .chain_err(|| ErrorKind::WindowsUninstallMadness));
 
     process::exit(0);
 }
 
 #[cfg(windows)]
 fn wait_for_parent() -> Result<()> {
-    use kernel32::{Process32First, Process32Next,
-                   CreateToolhelp32Snapshot, CloseHandle, OpenProcess,
-                   GetCurrentProcessId, WaitForSingleObject};
-    use winapi::{PROCESSENTRY32, INVALID_HANDLE_VALUE, DWORD, INFINITE,
-                 TH32CS_SNAPPROCESS, SYNCHRONIZE, WAIT_OBJECT_0};
+    use kernel32::{Process32First, Process32Next, CreateToolhelp32Snapshot, CloseHandle,
+                   OpenProcess, GetCurrentProcessId, WaitForSingleObject};
+    use winapi::{PROCESSENTRY32, INVALID_HANDLE_VALUE, DWORD, INFINITE, TH32CS_SNAPPROCESS,
+                 SYNCHRONIZE, WAIT_OBJECT_0};
     use std::io;
     use std::mem;
     use std::ptr;
@@ -735,7 +728,9 @@ fn wait_for_parent() -> Result<()> {
             return Err(err).chain_err(|| ErrorKind::WindowsUninstallMadness);
         }
 
-        let _g = scopeguard::guard(snapshot, |h| { let _ = CloseHandle(*h); });
+        let _g = scopeguard::guard(snapshot, |h| {
+            let _ = CloseHandle(*h);
+        });
 
         let mut entry: PROCESSENTRY32 = mem::zeroed();
         entry.dwSize = mem::size_of::<PROCESSENTRY32>() as DWORD;
@@ -768,7 +763,9 @@ fn wait_for_parent() -> Result<()> {
             return Ok(());
         }
 
-        let _g = scopeguard::guard(parent, |h| { let _ = CloseHandle(*h); });
+        let _g = scopeguard::guard(parent, |h| {
+            let _ = CloseHandle(*h);
+        });
 
         // Wait for our parent to exit
         let res = WaitForSingleObject(parent, INFINITE);
@@ -801,7 +798,7 @@ fn get_add_path_methods() -> Vec<PathUpdateMethod> {
     }
 
     let profile = utils::home_dir().map(|p| p.join(".profile"));
-    let rcfiles = vec![profile].into_iter().filter_map(|f|f);
+    let rcfiles = vec![profile].into_iter().filter_map(|f| f);
 
     rcfiles.map(|f| PathUpdateMethod::RcFile(f)).collect()
 }
@@ -864,13 +861,13 @@ fn do_add_to_path(methods: &[PathUpdateMethod]) -> Result<()> {
 
     let root = RegKey::predef(HKEY_CURRENT_USER);
     let environment = try!(root.open_subkey_with_flags("Environment", KEY_READ | KEY_WRITE)
-                           .chain_err(|| ErrorKind::PermissionDenied));
+        .chain_err(|| ErrorKind::PermissionDenied));
     let reg_value = RegValue {
         bytes: utils::string_to_winreg_bytes(&new_path),
         vtype: RegType::REG_EXPAND_SZ,
     };
     try!(environment.set_raw_value("PATH", &reg_value)
-         .chain_err(|| ErrorKind::PermissionDenied));
+        .chain_err(|| ErrorKind::PermissionDenied));
 
     // Tell other processes to update their environment
     unsafe {
@@ -897,7 +894,7 @@ fn get_windows_path_var() -> Result<Option<String>> {
 
     let root = RegKey::predef(HKEY_CURRENT_USER);
     let environment = try!(root.open_subkey_with_flags("Environment", KEY_READ | KEY_WRITE)
-                           .chain_err(|| ErrorKind::PermissionDenied));
+        .chain_err(|| ErrorKind::PermissionDenied));
 
     let reg_value = environment.get_raw_value("PATH");
     match reg_value {
@@ -905,17 +902,13 @@ fn get_windows_path_var() -> Result<Option<String>> {
             if let Some(s) = utils::string_from_winreg_value(&val) {
                 Ok(Some(s))
             } else {
-                warn!("the registry key HKEY_CURRENT_USER\\Environment\\PATH does not contain valid Unicode. \
-                       Not modifying the PATH variable");
+                warn!("the registry key HKEY_CURRENT_USER\\Environment\\PATH does not contain \
+                       valid Unicode. Not modifying the PATH variable");
                 return Ok(None);
             }
         }
-        Err(ref e) if e.kind() == io::ErrorKind::NotFound => {
-            Ok(Some(String::new()))
-        }
-        Err(e) => {
-            Err(e).chain_err(|| ErrorKind::WindowsUninstallMadness)
-        }
+        Err(ref e) if e.kind() == io::ErrorKind::NotFound => Ok(Some(String::new())),
+        Err(e) => Err(e).chain_err(|| ErrorKind::WindowsUninstallMadness),
     }
 }
 
@@ -930,16 +923,15 @@ fn get_remove_path_methods() -> Result<Vec<PathUpdateMethod>> {
 
     let rcfiles = vec![profile];
     let existing_rcfiles = rcfiles.into_iter()
-        .filter_map(|f|f)
+        .filter_map(|f| f)
         .filter(|f| f.exists());
 
     let export_str = try!(shell_export_string());
-    let matching_rcfiles = existing_rcfiles
-        .filter(|f| {
-            let file = utils::read_file("rcfile", f).unwrap_or(String::new());
-            let ref addition = format!("\n{}", export_str);
-            file.contains(addition)
-        });
+    let matching_rcfiles = existing_rcfiles.filter(|f| {
+        let file = utils::read_file("rcfile", f).unwrap_or(String::new());
+        let ref addition = format!("\n{}", export_str);
+        file.contains(addition)
+    });
 
     Ok(matching_rcfiles.map(|f| PathUpdateMethod::RcFile(f)).collect())
 }
@@ -976,21 +968,21 @@ fn do_remove_from_path(methods: &[PathUpdateMethod]) -> Result<()> {
     }
 
     let mut new_path = old_path[..idx].to_string();
-    new_path.push_str(&old_path[idx + len ..]);
+    new_path.push_str(&old_path[idx + len..]);
 
     let root = RegKey::predef(HKEY_CURRENT_USER);
     let environment = try!(root.open_subkey_with_flags("Environment", KEY_READ | KEY_WRITE)
-                           .chain_err(|| ErrorKind::PermissionDenied));
+        .chain_err(|| ErrorKind::PermissionDenied));
     if new_path.is_empty() {
         try!(environment.delete_value("PATH")
-             .chain_err(|| ErrorKind::PermissionDenied));
+            .chain_err(|| ErrorKind::PermissionDenied));
     } else {
         let reg_value = RegValue {
             bytes: utils::string_to_winreg_bytes(&new_path),
             vtype: RegType::REG_EXPAND_SZ,
         };
         try!(environment.set_raw_value("PATH", &reg_value)
-        .chain_err(|| ErrorKind::PermissionDenied));
+            .chain_err(|| ErrorKind::PermissionDenied));
     }
 
     // Tell other processes to update their environment
@@ -1077,8 +1069,7 @@ pub fn prepare_update() -> Result<Option<PathBuf>> {
     // Get build triple
     let triple = dist::TargetTriple::from_build();
 
-    let update_root = env::var("RUSTUP_UPDATE_ROOT")
-        .unwrap_or(String::from(UPDATE_ROOT));
+    let update_root = env::var("RUSTUP_UPDATE_ROOT").unwrap_or(String::from(UPDATE_ROOT));
 
     let tempdir = try!(TempDir::new("multirust-update")
         .chain_err(|| "error creating temp directory"));
@@ -1089,12 +1080,14 @@ pub fn prepare_update() -> Result<Option<PathBuf>> {
     // Calculate own hash
     let mut hasher = Sha256::new();
     let mut self_exe = try!(File::open(multirust_path)
-                        .chain_err(|| "can't open self exe to calculate hash"));
+        .chain_err(|| "can't open self exe to calculate hash"));
     let ref mut buf = [0; 4096];
     loop {
         let bytes = try!(self_exe.read(buf)
-                         .chain_err(|| "failed to read from self exe while calculating hash"));
-        if bytes == 0 { break; }
+            .chain_err(|| "failed to read from self exe while calculating hash"));
+        if bytes == 0 {
+            break;
+        }
         hasher.input(&buf[0..bytes]);
     }
     let current_hash = hasher.result_str();
@@ -1119,10 +1112,7 @@ pub fn prepare_update() -> Result<Option<PathBuf>> {
     // Download new version
     info!("downloading self-update");
     let mut hasher = Sha256::new();
-    try!(utils::download_file(&download_url,
-                              &setup_path,
-                              Some(&mut hasher),
-                              &|_| ()));
+    try!(utils::download_file(&download_url, &setup_path, Some(&mut hasher), &|_| ()));
     let download_hash = hasher.result_str();
 
     // Check that hash is correct
@@ -1149,7 +1139,8 @@ pub fn prepare_update() -> Result<Option<PathBuf>> {
 pub fn run_update(setup_path: &Path) -> Result<()> {
     let status = try!(Command::new(setup_path)
         .arg("--self-replace")
-        .status().chain_err(|| "unable to run updater"));
+        .status()
+        .chain_err(|| "unable to run updater"));
 
     if !status.success() {
         return Err("self-updated failed to replace multirust executable".into());
@@ -1162,7 +1153,8 @@ pub fn run_update(setup_path: &Path) -> Result<()> {
 pub fn run_update(setup_path: &Path) -> Result<()> {
     try!(Command::new(setup_path)
         .arg("--self-replace")
-        .spawn().chain_err(|| "unable to run updater"));
+        .spawn()
+        .chain_err(|| "unable to run updater"));
 
     process::exit(0);
 }

--- a/src/rustup-cli/setup_mode.rs
+++ b/src/rustup-cli/setup_mode.rs
@@ -19,31 +19,31 @@ pub fn main() -> Result<()> {
         .about("The installer for rustup")
         .setting(AppSettings::DeriveDisplayOrder)
         .arg(Arg::with_name("verbose")
-             .short("v")
-             .long("verbose")
-             .help("Enable verbose output"))
+            .short("v")
+            .long("verbose")
+            .help("Enable verbose output"))
         .arg(Arg::with_name("no-prompt")
-             .short("y")
-             .help("Disable confirmation prompt."))
+            .short("y")
+            .help("Disable confirmation prompt."))
         .arg(Arg::with_name("default-host")
-             .long("default-host")
-             .takes_value(true)
-             .help("Choose a default host triple"))
+            .long("default-host")
+            .takes_value(true)
+            .help("Choose a default host triple"))
         .arg(Arg::with_name("default-toolchain")
-             .long("default-toolchain")
-             .takes_value(true)
-             .possible_values(&["stable", "beta", "nightly"])
-             .help("Choose a default toolchain to install"))
+            .long("default-toolchain")
+            .takes_value(true)
+            .possible_values(&["stable", "beta", "nightly"])
+            .help("Choose a default toolchain to install"))
         .arg(Arg::with_name("no-modify-path")
-             .long("no-modify-path")
-             .help("Don't configure the PATH environment variable"));
+            .long("no-modify-path")
+            .help("Don't configure the PATH environment variable"));
 
     let matches = cli.get_matches();
     let no_prompt = matches.is_present("no-prompt");
     let verbose = matches.is_present("verbose");
-    let default_host = matches.value_of("default-host").map(|s| s.to_owned()).unwrap_or_else(|| {
-        TargetTriple::from_host_or_build().to_string()
-    });
+    let default_host = matches.value_of("default-host")
+        .map(|s| s.to_owned())
+        .unwrap_or_else(|| TargetTriple::from_host_or_build().to_string());
     let default_toolchain = matches.value_of("default-toolchain").unwrap_or("stable");
     let no_modify_path = matches.is_present("no-modify-path");
 

--- a/src/rustup-cli/term2.rs
+++ b/src/rustup-cli/term2.rs
@@ -16,11 +16,15 @@ pub trait Instantiable {
 }
 
 impl Instantiable for io::Stdout {
-    fn instance() -> Self { io::stdout() }
+    fn instance() -> Self {
+        io::stdout()
+    }
 }
 
 impl Instantiable for io::Stderr {
-    fn instance() -> Self { io::stderr() }
+    fn instance() -> Self {
+        io::stderr()
+    }
 }
 
 pub struct Terminal<T: Instantiable + io::Write>(Option<Box<term::Terminal<Output = T> + Send>>);
@@ -40,7 +44,7 @@ struct LineWrapper<'a, T: io::Write + 'a> {
     indent: u32,
     margin: u32,
     pos: u32,
-    pub w: &'a mut T
+    pub w: &'a mut T,
 }
 
 impl<'a, T: io::Write + 'a> LineWrapper<'a, T> {
@@ -108,7 +112,7 @@ impl<'a, T: io::Write + 'a> LineWrapper<'a, T> {
             indent: indent,
             margin: margin,
             pos: indent,
-            w: w
+            w: w,
         }
     }
 }
@@ -116,14 +120,14 @@ impl<'a, T: io::Write + 'a> LineWrapper<'a, T> {
 // Handles the formatting of text
 struct LineFormatter<'a, T: Instantiable + io::Write + 'a> {
     wrapper: LineWrapper<'a, Terminal<T>>,
-    attrs: Vec<Attr>
+    attrs: Vec<Attr>,
 }
 
 impl<'a, T: Instantiable + io::Write + 'a> LineFormatter<'a, T> {
     fn new(w: &'a mut Terminal<T>, indent: u32, margin: u32) -> Self {
         LineFormatter {
             wrapper: LineWrapper::new(w, indent, margin),
-            attrs: Vec::new()
+            attrs: Vec::new(),
         }
     }
     fn push_attr(&mut self, attr: Attr) {
@@ -140,15 +144,15 @@ impl<'a, T: Instantiable + io::Write + 'a> LineFormatter<'a, T> {
     fn do_spans(&mut self, spans: Vec<Span>) {
         for span in spans {
             match span {
-                Span::Break => {},
+                Span::Break => {}
                 Span::Text(text) => {
                     self.wrapper.write_span(&text);
-                },
+                }
                 Span::Code(code) => {
                     self.push_attr(Attr::Bold);
                     self.wrapper.write_word(&code);
                     self.pop_attr();
-                },
+                }
                 Span::Emphasis(spans) => {
                     self.push_attr(Attr::ForegroundColor(color::BRIGHT_RED));
                     self.do_spans(spans);
@@ -166,7 +170,7 @@ impl<'a, T: Instantiable + io::Write + 'a> LineFormatter<'a, T> {
                 self.do_spans(spans);
                 self.wrapper.write_line();
                 self.pop_attr();
-            },
+            }
             Block::CodeBlock(code) => {
                 self.wrapper.write_line();
                 self.wrapper.indent += 2;
@@ -176,12 +180,12 @@ impl<'a, T: Instantiable + io::Write + 'a> LineFormatter<'a, T> {
                     self.wrapper.write_line();
                 }
                 self.wrapper.indent -= 2;
-            },
+            }
             Block::Paragraph(spans) => {
                 self.wrapper.write_line();
                 self.do_spans(spans);
                 self.wrapper.write_line();
-            },
+            }
             Block::UnorderedList(items) => {
                 self.wrapper.write_line();
                 for item in items {
@@ -189,7 +193,7 @@ impl<'a, T: Instantiable + io::Write + 'a> LineFormatter<'a, T> {
                     match item {
                         ListItem::Simple(spans) => {
                             self.do_spans(spans);
-                        },
+                        }
                         ListItem::Paragraph(blocks) => {
                             for block in blocks {
                                 self.do_block(block);
@@ -227,7 +231,9 @@ impl<T: Instantiable + io::Write> io::Write for Terminal<T> {
 
 impl<T: Instantiable + io::Write> Terminal<T> {
     pub fn fg(&mut self, color: color::Color) -> Result<(), term::Error> {
-        if !tty::stderr_isatty() { return Ok(()) }
+        if !tty::stderr_isatty() {
+            return Ok(());
+        }
 
         if let Some(ref mut t) = self.0 {
             t.fg(color)
@@ -237,14 +243,16 @@ impl<T: Instantiable + io::Write> Terminal<T> {
     }
 
     pub fn attr(&mut self, attr: Attr) -> Result<(), term::Error> {
-        if !tty::stderr_isatty() { return Ok(()) }
+        if !tty::stderr_isatty() {
+            return Ok(());
+        }
 
         if let Some(ref mut t) = self.0 {
             if let Err(e) = t.attr(attr) {
                 // If `attr` is not supported, try to emulate it
                 match attr {
                     Attr::Bold => t.fg(color::BRIGHT_WHITE),
-                    _ => Err(e)
+                    _ => Err(e),
                 }
             } else {
                 Ok(())
@@ -255,7 +263,9 @@ impl<T: Instantiable + io::Write> Terminal<T> {
     }
 
     pub fn reset(&mut self) -> Result<(), term::Error> {
-        if !tty::stderr_isatty() { return Ok(()) }
+        if !tty::stderr_isatty() {
+            return Ok(());
+        }
 
         if let Some(ref mut t) = self.0 {
             t.reset()

--- a/src/rustup/command.rs
+++ b/src/rustup/command.rs
@@ -13,9 +13,7 @@ use rustup_utils;
 use telemetry::{Telemetry, TelemetryEvent};
 
 
-pub fn run_command_for_dir<S: AsRef<OsStr>>(cmd: Command,
-                                            args: &[S],
-                                            cfg: &Cfg) -> Result<()> {
+pub fn run_command_for_dir<S: AsRef<OsStr>>(cmd: Command, args: &[S], cfg: &Cfg) -> Result<()> {
     let arg0 = env::args().next().map(|a| PathBuf::from(a));
     let arg0 = arg0.as_ref()
         .and_then(|a| a.file_name())
@@ -38,8 +36,7 @@ fn telemetry_rustc<S: AsRef<OsStr>>(mut cmd: Command, args: &[S], cfg: &Cfg) -> 
         e.starts_with("--color")
     });
 
-    if stderr_isatty() && !has_color_args
-    {
+    if stderr_isatty() && !has_color_args {
         cmd.arg("--color");
         cmd.arg("always");
     }
@@ -47,10 +44,10 @@ fn telemetry_rustc<S: AsRef<OsStr>>(mut cmd: Command, args: &[S], cfg: &Cfg) -> 
     // FIXME rust-lang/rust#32254. It's not clear to me
     // when and why this is needed.
     let mut cmd = cmd.stdin(Stdio::inherit())
-                    .stdout(Stdio::inherit())
-                    .stderr(Stdio::piped())
-                    .spawn()
-                    .unwrap();
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
 
     let mut buffered_stderr = BufReader::new(cmd.stderr.take().unwrap());
     let status = cmd.wait();
@@ -96,34 +93,40 @@ fn telemetry_rustc<S: AsRef<OsStr>>(mut cmd: Command, args: &[S], cfg: &Cfg) -> 
                 _ => Some(errors),
             };
 
-            let te = TelemetryEvent::RustcRun { duration_ms: ms,
-                                                exit_code: exit_code,
-                                                errors: e };
+            let te = TelemetryEvent::RustcRun {
+                duration_ms: ms,
+                exit_code: exit_code,
+                errors: e,
+            };
 
             let _ = t.log_telemetry(te).map_err(|xe| {
                 (cfg.notify_handler)(Notification::TelemetryCleanupError(&xe));
             });
 
             process::exit(exit_code);
-        },
+        }
         Err(e) => {
             let exit_code = e.raw_os_error().unwrap_or(1);
-            let te = TelemetryEvent::RustcRun { duration_ms: ms,
-                                                exit_code: exit_code,
-                                                errors: None };
+            let te = TelemetryEvent::RustcRun {
+                duration_ms: ms,
+                exit_code: exit_code,
+                errors: None,
+            };
 
             let _ = t.log_telemetry(te).map_err(|xe| {
                 (cfg.notify_handler)(Notification::TelemetryCleanupError(&xe));
             });
 
-            Err(e).chain_err(|| rustup_utils::ErrorKind::RunningCommand {
-                name: args[0].as_ref().to_owned(),
+            Err(e).chain_err(|| {
+                rustup_utils::ErrorKind::RunningCommand { name: args[0].as_ref().to_owned() }
             })
-        },
+        }
     }
 }
 
-fn run_command_for_dir_without_telemetry<S: AsRef<OsStr>>(mut cmd: Command, args: &[S]) -> Result<()>  {
+fn run_command_for_dir_without_telemetry<S: AsRef<OsStr>>(mut cmd: Command,
+                                                          args: &[S])
+                                                          -> Result<()> {
     cmd.args(&args[1..]);
 
     // FIXME rust-lang/rust#32254. It's not clear to me
@@ -137,8 +140,8 @@ fn run_command_for_dir_without_telemetry<S: AsRef<OsStr>>(mut cmd: Command, args
             process::exit(code);
         }
         Err(e) => {
-            Err(e).chain_err(|| rustup_utils::ErrorKind::RunningCommand {
-                name: args[0].as_ref().to_owned(),
+            Err(e).chain_err(|| {
+                rustup_utils::ErrorKind::RunningCommand { name: args[0].as_ref().to_owned() }
             })
         }
     }
@@ -158,8 +161,7 @@ fn stderr_isatty() -> bool {
     const STD_ERROR_HANDLE: DWORD = -12i32 as DWORD;
     extern "system" {
         fn GetStdHandle(which: DWORD) -> HANDLE;
-        fn GetConsoleMode(hConsoleHandle: HANDLE,
-                          lpMode: *mut DWORD) -> BOOL;
+        fn GetConsoleMode(hConsoleHandle: HANDLE, lpMode: *mut DWORD) -> BOOL;
     }
     unsafe {
         let handle = GetStdHandle(STD_ERROR_HANDLE);

--- a/src/rustup/env_var.rs
+++ b/src/rustup/env_var.rs
@@ -30,9 +30,9 @@ pub fn prepend_path(name: &str, value: &Path, cmd: &mut Command) {
 
 pub fn inc(name: &str, cmd: &mut Command) {
     let old_value = env::var(name)
-                        .ok()
-                        .and_then(|v| v.parse().ok())
-                        .unwrap_or(0);
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
 
     cmd.env(name, (old_value + 1).to_string());
 }

--- a/src/rustup/install.rs
+++ b/src/rustup/install.rs
@@ -1,7 +1,7 @@
 //! Installation and upgrade of both distribution-managed and local
 //! toolchains
 
-use rustup_dist::{Notification};
+use rustup_dist::Notification;
 use rustup_dist::prefix::InstallPrefix;
 use rustup_utils::utils;
 use rustup_dist::temp;
@@ -47,12 +47,7 @@ impl<'a> InstallMethod<'a> {
             InstallMethod::Dist(toolchain, update_hash, dl_cfg) => {
                 let ref prefix = InstallPrefix::from(path.to_owned());
                 let maybe_new_hash =
-                    try!(dist::update_from_dist(
-                        dl_cfg,
-                        update_hash,
-                        toolchain,
-                        prefix,
-                        &[], &[]));
+                    try!(dist::update_from_dist(dl_cfg, update_hash, toolchain, prefix, &[], &[]));
 
                 if let Some(hash) = maybe_new_hash {
                     if let Some(hash_file) = update_hash {
@@ -67,8 +62,11 @@ impl<'a> InstallMethod<'a> {
         }
     }
 
-    fn tar_gz(src: &Path, path: &Path, temp_cfg: &temp::Cfg,
-              notify_handler: &Fn(Notification)) -> Result<()> {
+    fn tar_gz(src: &Path,
+              path: &Path,
+              temp_cfg: &temp::Cfg,
+              notify_handler: &Fn(Notification))
+              -> Result<()> {
         notify_handler(Notification::Extracting(src, path));
 
         let prefix = InstallPrefix::from(path.to_owned());
@@ -88,6 +86,5 @@ impl<'a> InstallMethod<'a> {
 }
 
 pub fn uninstall(path: &Path, notify_handler: &Fn(Notification)) -> Result<()> {
-    Ok(try!(utils::remove_dir("install", path,
-                              &|n| notify_handler(n.into()))))
+    Ok(try!(utils::remove_dir("install", path, &|n| notify_handler(n.into()))))
 }

--- a/src/rustup/notifications.rs
+++ b/src/rustup/notifications.rs
@@ -108,9 +108,7 @@ impl<'a> Display for Notification<'a> {
             UninstallingToolchain(name) => write!(f, "uninstalling toolchain '{}'", name),
             UninstalledToolchain(name) => write!(f, "toolchain '{}' uninstalled", name),
             ToolchainNotInstalled(name) => write!(f, "no toolchain installed for '{}'", name),
-            UpdateHashMatches => {
-                write!(f, "toolchain is already up to date")
-            }
+            UpdateHashMatches => write!(f, "toolchain is already up to date"),
             UpgradingMetadata(from_ver, to_ver) => {
                 write!(f,
                        "upgrading metadata version from '{}' to '{}'",
@@ -125,9 +123,15 @@ impl<'a> Display for Notification<'a> {
             WritingMetadataVersion(ver) => write!(f, "writing metadata version: '{}'", ver),
             ReadMetadataVersion(ver) => write!(f, "read metadata version: '{}'", ver),
             NonFatalError(e) => write!(f, "{}", e),
-            UpgradeRemovesToolchains => write!(f, "this upgrade will remove all existing toolchains. you will need to reinstall them"),
+            UpgradeRemovesToolchains => {
+                write!(f,
+                       "this upgrade will remove all existing toolchains. you will need to \
+                        reinstall them")
+            }
             MissingFileDuringSelfUninstall(ref p) => {
-                write!(f, "expected file does not exist to uninstall: {}", p.display())
+                write!(f,
+                       "expected file does not exist to uninstall: {}",
+                       p.display())
             }
             SetTelemetry(telemetry_status) => write!(f, "telemetry set to '{}'", telemetry_status),
             TelemetryCleanupError(e) => write!(f, "unable to remove old telemetry files: '{}'", e),

--- a/src/rustup/settings.rs
+++ b/src/rustup/settings.rs
@@ -15,14 +15,14 @@ pub const DEFAULT_METADATA_VERSION: &'static str = "12";
 #[derive(Clone, Debug, PartialEq)]
 pub struct SettingsFile {
     path: PathBuf,
-    cache: RefCell<Option<Settings>>
+    cache: RefCell<Option<Settings>>,
 }
 
 impl SettingsFile {
     pub fn new(path: PathBuf) -> Self {
         SettingsFile {
             path: path,
-            cache: RefCell::new(None)
+            cache: RefCell::new(None),
         }
     }
     fn write_settings(&self) -> Result<()> {
@@ -73,7 +73,7 @@ impl SettingsFile {
                 s.find(separator).and_then(|index| {
                     match (T::from_str(&s[..index]), T::from_str(&s[index + 1..])) {
                         (Ok(l), Ok(r)) => Some((l, r)),
-                        _ => None
+                        _ => None,
                     }
                 })
             }
@@ -84,11 +84,13 @@ impl SettingsFile {
             // Legacy upgrade
             try!(self.with_mut(|s| {
                 s.version = try!(utils::read_file("version", &legacy_version_file))
-                    .trim().to_owned();
+                    .trim()
+                    .to_owned();
 
                 if utils::is_file(&default_file) {
                     s.default_toolchain = Some(try!(utils::read_file("default", &default_file))
-                        .trim().to_owned());
+                        .trim()
+                        .to_owned());
                 }
                 if utils::is_file(&override_db) {
                     let overrides = try!(utils::read_file("overrides", &override_db));
@@ -127,7 +129,7 @@ pub struct Settings {
     pub default_host_triple: Option<String>,
     pub default_toolchain: Option<String>,
     pub overrides: BTreeMap<String, String>,
-    pub telemetry: TelemetryMode
+    pub telemetry: TelemetryMode,
 }
 
 impl Default for Settings {
@@ -137,7 +139,7 @@ impl Default for Settings {
             default_host_triple: None,
             default_toolchain: None,
             overrides: BTreeMap::new(),
-            telemetry: TelemetryMode::Off
+            telemetry: TelemetryMode::Off,
         }
     }
 }
@@ -145,8 +147,8 @@ impl Default for Settings {
 impl Settings {
     fn path_to_key(path: &Path, notify_handler: &Fn(Notification)) -> String {
         utils::canonicalize_path(path, &|n| notify_handler(n.into()))
-               .display()
-               .to_string()
+            .display()
+            .to_string()
     }
 
     pub fn remove_override(&mut self, path: &Path, notify_handler: &Fn(Notification)) -> bool {
@@ -154,14 +156,19 @@ impl Settings {
         self.overrides.remove(&key).is_some()
     }
 
-    pub fn add_override(&mut self, path: &Path, toolchain: String, notify_handler: &Fn(Notification)) {
+    pub fn add_override(&mut self,
+                        path: &Path,
+                        toolchain: String,
+                        notify_handler: &Fn(Notification)) {
         let key = Self::path_to_key(path, notify_handler);
         notify_handler(Notification::SetOverrideToolchain(path, &toolchain));
         self.overrides.insert(key, toolchain);
     }
 
-    pub fn find_override(&self, dir_unresolved: &Path, notify_handler: &Fn(Notification))
-            -> Option<(String, PathBuf)> {
+    pub fn find_override(&self,
+                         dir_unresolved: &Path,
+                         notify_handler: &Fn(Notification))
+                         -> Option<(String, PathBuf)> {
         let dir = utils::canonicalize_path(dir_unresolved, &|n| notify_handler(n.into()));
         let mut maybe_path = Some(&*dir);
         while let Some(path) = maybe_path {
@@ -176,7 +183,8 @@ impl Settings {
 
     pub fn parse(data: &str) -> Result<Self> {
         let mut parser = toml::Parser::new(data);
-        let value = try!(parser.parse().ok_or_else(move || ErrorKind::ParsingSettings(parser.errors)));
+        let value = try!(parser.parse()
+            .ok_or_else(move || ErrorKind::ParsingSettings(parser.errors)));
 
         Self::from_toml(value, "")
     }
@@ -198,14 +206,13 @@ impl Settings {
                 TelemetryMode::On
             } else {
                 TelemetryMode::Off
-            }
+            },
         })
     }
     pub fn to_toml(self) -> toml::Table {
         let mut result = toml::Table::new();
 
-        result.insert("version".to_owned(),
-                      toml::Value::String(self.version));
+        result.insert("version".to_owned(), toml::Value::String(self.version));
 
         if let Some(v) = self.default_host_triple {
             result.insert("default_host_triple".to_owned(), toml::Value::String(v));

--- a/src/rustup/telemetry.rs
+++ b/src/rustup/telemetry.rs
@@ -8,9 +8,20 @@ use std::path::PathBuf;
 
 #[derive(RustcDecodable, RustcEncodable, Debug, Clone)]
 pub enum TelemetryEvent {
-    RustcRun { duration_ms: u64, exit_code: i32, errors: Option<Vec<String>> },
-    ToolchainUpdate { toolchain: String, success: bool } ,
-    TargetAdd { toolchain: String, target: String, success: bool },
+    RustcRun {
+        duration_ms: u64,
+        exit_code: i32,
+        errors: Option<Vec<String>>,
+    },
+    ToolchainUpdate {
+        toolchain: String,
+        success: bool,
+    },
+    TargetAdd {
+        toolchain: String,
+        target: String,
+        success: bool,
+    },
 }
 
 #[derive(RustcDecodable, RustcEncodable, Debug)]
@@ -28,7 +39,7 @@ impl LogMessage {
 
 #[derive(Debug)]
 pub struct Telemetry {
-    telemetry_dir: PathBuf
+    telemetry_dir: PathBuf,
 }
 
 const LOG_FILE_VERSION: i32 = 1;
@@ -41,13 +52,18 @@ impl Telemetry {
 
     pub fn log_telemetry(&self, event: TelemetryEvent) -> Result<()> {
         let current_time = time::now_utc();
-        let ln = LogMessage { log_time_s: current_time.to_timespec().sec,
-                              event: event,
-                              version: LOG_FILE_VERSION };
+        let ln = LogMessage {
+            log_time_s: current_time.to_timespec().sec,
+            event: event,
+            version: LOG_FILE_VERSION,
+        };
 
         let json = json::encode(&ln).unwrap();
 
-        let filename = format!("log-{}-{:02}-{:02}.json", current_time.tm_year + 1900, current_time.tm_mon + 1, current_time.tm_mday);
+        let filename = format!("log-{}-{:02}-{:02}.json",
+                               current_time.tm_year + 1900,
+                               current_time.tm_mon + 1,
+                               current_time.tm_mday);
 
         // Check for the telemetry file. If it doesn't exist, it's a new day.
         // If it is a new day, then attempt to clean the telemetry directory.
@@ -55,9 +71,7 @@ impl Telemetry {
             try!(self.clean_telemetry_dir());
         }
 
-        let _ = utils::append_file("telemetry",
-                                   &self.telemetry_dir.join(&filename),
-                                   &json);
+        let _ = utils::append_file("telemetry", &self.telemetry_dir.join(&filename), &json);
 
         Ok(())
     }
@@ -89,7 +103,8 @@ impl Telemetry {
 
         for i in 0..dl {
             let i = i as usize;
-            try!(fs::remove_file(&telemetry_files[i]).chain_err(|| ErrorKind::TelemetryCleanupError));
+            try!(fs::remove_file(&telemetry_files[i])
+                .chain_err(|| ErrorKind::TelemetryCleanupError));
         }
 
         Ok(())


### PR DESCRIPTION
Feel free to ignore this or shoot it down, but it seems that if this project is a part of rust-lang, it should follow the rust standard formatting guidelines. The only thing that I did in this commit was run `cargo fmt`.