### PR TITLE
Teach rustup to download manifests from the `/staging/` directory

### DIFF
--- a/src/rustup-dist/src/dist.rs
+++ b/src/rustup-dist/src/dist.rs
@@ -318,9 +318,12 @@ impl ToolchainDesc {
     }
 
     pub fn manifest_v1_url(&self, dist_root: &str) -> String {
-        match self.date {
-            None => format!("{}/channel-rust-{}", dist_root, self.channel),
-            Some(ref date) => format!("{}/{}/channel-rust-{}", dist_root, date, self.channel),
+        let do_manifest_staging = env::var("RUSTUP_STAGED_MANIFEST").is_ok();
+        match (self.date.as_ref(), do_manifest_staging) {
+            (None, false) => format!("{}/channel-rust-{}", dist_root, self.channel),
+            (Some(date), false) => format!("{}/{}/channel-rust-{}", dist_root, date, self.channel),
+            (None, true) => format!("{}/staging/channel-rust-{}", dist_root, self.channel),
+            (Some(_), true) => panic!("not a real-world case"),
         }
     }
 


### PR DESCRIPTION
With the changes to `RUSTUP_DIST_SERVER` to automitally replace URLS
in the manifest, it's no longer usable to test Rust pre-releases!

The `RUSTUP_STAGED_MANIFEST` flag tells rustup to download *just* the
manifest from the `/staging/` directory on s.rlo.