### PR TITLE
Allow any toolchain to be specified as the default during rustup installation.

### DIFF
--- a/src/rustup-cli/setup_mode.rs
+++ b/src/rustup-cli/setup_mode.rs
@@ -32,7 +32,6 @@ pub fn main() -> Result<()> {
         .arg(Arg::with_name("default-toolchain")
              .long("default-toolchain")
              .takes_value(true)
-             .possible_values(&["stable", "beta", "nightly"])
              .help("Choose a default toolchain to install"))
         .arg(Arg::with_name("no-modify-path")
              .long("no-modify-path")

--- a/tests/cli-inst-interactive.rs
+++ b/tests/cli-inst-interactive.rs
@@ -140,6 +140,18 @@ fn with_non_default_toolchain() {
 }
 
 #[test]
+fn with_non_release_channel_non_default_toolchain() {
+    setup(&|config| {
+        let out = run_input(config, &["rustup-init", "--default-toolchain=nightly-2015-01-02"],
+                            "\n\n");
+        assert!(out.ok);
+
+        expect_stdout_ok(config, &["rustup", "show"], "nightly");
+        expect_stdout_ok(config, &["rustup", "show"], "2015-01-02");
+    });
+}
+
+#[test]
 fn set_nightly_toolchain() {
     setup(&|config| {
         let out = run_input(config, &["rustup-init"],


### PR DESCRIPTION
Instead of restricting the `--default-toolchain` argument to `rustup-init` to one of the release channel names, allow any toolchain specification, but warn the user if they do so, since this makes it easier to accidentally install rustup with an invalid toolchain name.

Fixes #559.