### PR TITLE
Read/Write impl rework for rustls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "bitflags"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,7 +203,7 @@ dependencies = [
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.1.0 (git+https://github.com/sfackler/rust-native-tls.git)",
  "openssl-sys 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustls 0.1.0 (git+https://github.com/inejge/rustls.git?branch=new-wantsread)",
+ "rustls 0.1.0 (git+https://github.com/ctz/rustls.git)",
  "url 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -542,11 +547,11 @@ dependencies = [
 [[package]]
 name = "rustls"
 version = "0.1.0"
-source = "git+https://github.com/inejge/rustls.git?branch=new-wantsread#3b97e2018ca103a7d98691a7c6c97a097c82da96"
+source = "git+https://github.com/ctz/rustls.git#5b96b9c5ea7e0d45ee31387c488ecd2a6a02266f"
 dependencies = [
+ "base64 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.1.0 (git+https://github.com/ctz/ring)",
- "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "webpki 0.1.0 (git+https://github.com/ctz/webpki)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,7 +198,7 @@ dependencies = [
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.1.0 (git+https://github.com/sfackler/rust-native-tls.git)",
  "openssl-sys 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustls 0.1.0 (git+https://github.com/ctz/rustls.git)",
+ "rustls 0.1.0 (git+https://github.com/inejge/rustls.git?branch=new-wantsread)",
  "url 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -542,7 +542,7 @@ dependencies = [
 [[package]]
 name = "rustls"
 version = "0.1.0"
-source = "git+https://github.com/ctz/rustls.git#622dce5fdbd3b644e4e79d5d6e3dc891590121dc"
+source = "git+https://github.com/inejge/rustls.git?branch=new-wantsread#3b97e2018ca103a7d98691a7c6c97a097c82da96"
 dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.1.0 (git+https://github.com/ctz/ring)",

--- a/src/download/Cargo.toml
+++ b/src/download/Cargo.toml
@@ -33,7 +33,8 @@ optional = true
 openssl-sys = { version = "0.7.11", optional = true }
 
 [dependencies.rustls]
-git = "https://github.com/ctz/rustls.git"
+git = "https://github.com/inejge/rustls.git"
+branch = "new-wantsread"
 optional = true
 
 [dependencies.ca-loader]

--- a/src/download/Cargo.toml
+++ b/src/download/Cargo.toml
@@ -33,8 +33,7 @@ optional = true
 openssl-sys = { version = "0.7.11", optional = true }
 
 [dependencies.rustls]
-git = "https://github.com/inejge/rustls.git"
-branch = "new-wantsread"
+git = "https://github.com/ctz/rustls.git"
 optional = true
 
 [dependencies.ca-loader]

--- a/src/download/src/lib.rs
+++ b/src/download/src/lib.rs
@@ -491,8 +491,18 @@ pub mod rustls {
                 .and_then(|mut t| {
                     let (ref mut stream, ref mut tls) = *t;
                     while tls.wants_read() {
-                        tls.read_tls(stream).unwrap(); // FIXME
-                        tls.process_new_packets().unwrap(); // FIXME
+                        match tls.read_tls(stream) {
+			    Ok(_) => {
+				match tls.process_new_packets() {
+				    Ok(_) => (),
+				    Err(e) => return Err(io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))
+				}
+				while tls.wants_write() {
+				    try!(tls.write_tls(stream));
+				}
+			    },
+			    Err(e) => return Err(e),
+			}
                     }
 
                     tls.read(buf)
@@ -507,11 +517,9 @@ pub mod rustls {
             self.lock()
                 .and_then(|mut t| {
                     let (ref mut stream, ref mut tls) = *t;
-
                     let res = tls.write(buf);
-
                     while tls.wants_write() {
-                        tls.write_tls(stream).unwrap(); // FIXME
+                        try!(tls.write_tls(stream));
                     }
 
                     res

--- a/src/download/src/lib.rs
+++ b/src/download/src/lib.rs
@@ -366,6 +366,7 @@ pub mod rustls {
     use hyper_base;
     use self::hyper::error::Result as HyperResult;
     use self::hyper::net::{SslClient, NetworkStream};
+    use self::rustls::Session;
     use std::io::Result as IoResult;
     use std::io::{Read, Write};
     use std::net::{SocketAddr, Shutdown};


### PR DESCRIPTION
Further tweaks for #568: rustls-enabled rustup can now actually download content. I think that merging should wait, though, since I don't think I thoroughly understand the consequences of the modifications I've had to make both to rustup and rustls in order to make it happen (which is why I've switched it to a private fork for the time being.)

rustls really, really wants to be driven asynchronously, and adapting it to synchronous-style hyper involved manually inserting calls to `write_tls()` after processing input packets in the `Read` impl (without which the protocol negotiation would hang.) Also, `wants_read()` in rustls used to return `true` all the time; I modified it to track the size of its plaintext buffer, so that further `read_tls()` calls are triggered only when that buffer is empty. It seems to work, but I'm not sure what happens when the other side sends an alert, or forcibly closes the connection.

cc @ctz