### PR TITLE
Detect ARMv7 CPUs without NEON extensions and treat as ARMv6

### DIFF
--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -177,6 +177,16 @@ get_architecture() {
         fi
     fi
 
+    # Detect armv7 but without the CPU features Rust needs in that build,
+    # and fall back to arm.
+    # See https://github.com/rust-lang-nursery/rustup.rs/issues/587.
+    if [ $_ostype = "unknown-linux-gnueabihf" -a $_cputype = armv7 ]; then
+        if ensure grep '^Features' /proc/cpuinfo | grep -q -v neon; then
+            # At least one processor does not have NEON.
+            local _cputype=arm
+        fi
+    fi
+
     local _arch="$_cputype-$_ostype"
 
     RETVAL="$_arch"


### PR DESCRIPTION
Fixes rust-lang-nursery/rustup.rs/issues/587