### PR TITLE
Use the env_proxy crate for proxy environment variable handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,12 +193,21 @@ version = "0.3.0"
 dependencies = [
  "ca-loader 0.1.0",
  "curl 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_proxy 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.1.0 (git+https://github.com/sfackler/rust-native-tls.git)",
  "openssl-sys 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustls 0.1.0 (git+https://github.com/ctz/rustls.git)",
+ "url 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "env_proxy"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
  "url 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/src/download/Cargo.toml
+++ b/src/download/Cargo.toml
@@ -11,8 +11,8 @@ license = "MIT/Apache-2.0"
 default = ["hyper-backend"]
 
 curl-backend = ["curl"]
-hyper-backend = ["hyper", "native-tls", "openssl-sys"]
-rustls-backend = ["hyper", "rustls", "lazy_static", "ca-loader"]
+hyper-backend = ["hyper", "env_proxy", "native-tls", "openssl-sys"]
+rustls-backend = ["hyper", "env_proxy", "rustls", "lazy_static", "ca-loader"]
 
 [dependencies]
 error-chain = "0.2.1"
@@ -23,6 +23,10 @@ lazy_static = { version = "0.2", optional = true }
 [dependencies.hyper]
 version = "0.9.8"
 default-features = false
+optional = true
+
+[dependencies.env_proxy]
+version = "0.1.1"
 optional = true
 
 [dependencies.native-tls]


### PR DESCRIPTION
The crate [env_proxy](https://crates.io/crates/env_proxy) encapsulates the rules for selecting the appropriate proxy server for a target URL according to the contents of the current environment, closely following the convention used by __curl__. This PR replaces the local (and incomplete) proxy determination function with the one provided by that crate.