### PR TITLE
Hide telemetry command from top level help

### DIFF
--- a/src/rustup-cli/rustup_mode.rs
+++ b/src/rustup-cli/rustup_mode.rs
@@ -263,6 +263,7 @@ pub fn cli() -> App<'static, 'static> {
                 .about("Upgrade the internal data format.")))
         .subcommand(SubCommand::with_name("telemetry")
             .about("rustup telemetry commands")
+            .setting(AppSettings::Hidden)
             .setting(AppSettings::VersionlessSubcommands)
             .setting(AppSettings::DeriveDisplayOrder)
             .setting(AppSettings::SubcommandRequiredElseHelp)


### PR DESCRIPTION
But `rustup telemetry` will still print the subcommand-specific help.

Fixes #594