### PR TITLE
Widen the range of entries seen as toolchains

### DIFF
--- a/src/rustup/config.rs
+++ b/src/rustup/config.rs
@@ -252,7 +252,7 @@ impl Cfg {
         if utils::is_directory(&self.toolchains_dir) {
             let mut toolchains: Vec<_> = try!(utils::read_dir("toolchains", &self.toolchains_dir))
                                          .filter_map(io::Result::ok)
-                                         .filter(|e| e.file_type().map(|f| f.is_dir()).unwrap_or(false))
+                                         .filter(|e| e.file_type().map(|f| !f.is_file()).unwrap_or(false))
                                          .filter_map(|e| e.file_name().into_string().ok())
                                          .collect();
 

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -260,6 +260,10 @@ fn link() {
         expect_ok(config, &["rustup", "default", "custom"]);
         expect_stdout_ok(config, &["rustc", "--version"],
                          "hash-c-1");
+        expect_ok(config, &["rustup", "update", "nightly"]);
+        expect_ok(config, &["rustup", "default", "nightly"]);
+        expect_stdout_ok(config, &["rustup", "show"],
+                         "custom");
     });
 }
 


### PR DESCRIPTION
If only directory entries are chosen with `is_dir()`, the list will miss the symlinks/junctions to custom toolchains.

Fixes #603