### PR TITLE
Handle active custom toolchain in "show"

### DIFF
--- a/src/rustup-cli/rustup_mode.rs
+++ b/src/rustup-cli/rustup_mode.rs
@@ -453,11 +453,14 @@ fn show(cfg: &Cfg) -> Result<()> {
     let installed_toolchains = try!(cfg.list_toolchains());
     let active_toolchain = try!(cfg.find_override_toolchain_or_default(cwd));
     let active_targets = if let Some((ref t, _)) = active_toolchain {
-        try!(t.list_components())
-            .into_iter()
-            .filter(|c| c.component.pkg == "rust-std")
-            .filter(|c| c.installed)
-            .collect()
+        match t.list_components() {
+	    Ok(cs_vec) => cs_vec
+		.into_iter()
+		.filter(|c| c.component.pkg == "rust-std")
+		.filter(|c| c.installed)
+		.collect(),
+	    Err(_) => vec![]
+	}
     } else {
         vec![]
     };

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -260,6 +260,8 @@ fn link() {
         expect_ok(config, &["rustup", "default", "custom"]);
         expect_stdout_ok(config, &["rustc", "--version"],
                          "hash-c-1");
+        expect_stdout_ok(config, &["rustup", "show"],
+                         "custom (default)");
         expect_ok(config, &["rustup", "update", "nightly"]);
         expect_ok(config, &["rustup", "default", "nightly"]);
         expect_stdout_ok(config, &["rustup", "show"],


### PR DESCRIPTION
Re #599. This is more complicated than it seems, because `show` tries to fetch all components of the active toolchain, and a custom toolchain a) doesn't have them, and b) doesn't even have an enforced name form. This set of patches enforces the __custom-__ prefix for custom toolchains and adds the minimum necessary logic to handle them in `show`. It also updates the README to note the new requirement.

__Edit__: whoops, wrong approach. I think I'll force push the new commits, the original ones are pointless.