### PR TITLE
adds --path and --nonexistent options to "rustup override unset";

### DIFF
--- a/src/rustup-cli/common.rs
+++ b/src/rustup-cli/common.rs
@@ -8,6 +8,7 @@ use rustup_utils::notify::NotificationLevel;
 use self_update;
 use std::io::{Write, BufRead};
 use std::process::Command;
+use std::path::Path;
 use std::{cmp, iter};
 use std::sync::Arc;
 use std;
@@ -286,12 +287,26 @@ pub fn list_overrides(cfg: &Cfg) -> Result<()> {
     let overrides = try!(cfg.settings_file.with(|s| Ok(s.overrides.clone())));
 
     if overrides.is_empty() {
-        println!("no overrides");
+        println!("No overrides.");
     } else {
+        println!("Overrides:");
+        let mut any_not_exist = false;
         for (k, v) in overrides {
-            println!("{:<40}\t{:<20}",
-                     utils::format_path_for_display(&k),
+            let dir_exists = Path::new(&k).is_dir();
+            if !dir_exists {
+                any_not_exist = true;
+            }
+            println!("  {:<40}\t{:<20}",
+                     utils::format_path_for_display(&k) +
+                     if dir_exists {
+                         ""
+                     } else {
+                         " (not a directory)"
+                     },
                      v)
+        }
+        if any_not_exist {
+            info!("you may remove overrides for non-existent directories with `rustup override unset --nonexistent`");
         }
     }
     Ok(())


### PR DESCRIPTION
adds hint to "rustup override list output"
(as discussed in #642)