### PR TITLE
Deploy MSI build artifacts

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,12 +55,12 @@ test_script:
   - cargo test --release --target %TARGET% %FEATURES%
   - ps: |
       if($env:BUILD_MSI) {
-        cd src\rustup-win-installer
+        pushd src\rustup-win-installer
         cargo build --release --target $env:TARGET
         cd msi
         .\build.ps1 -Target $env:TARGET
-        cd ..\..\..
-        if($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
+        popd
+        if($LastExitCode -ne 0) { exit $LastExitCode }
       }
 
 notifications:
@@ -79,6 +79,10 @@ artifacts:
     name: rustup-setup
   - path: dist\$(TARGET)\rustup-setup.exe.sha256
     name: rustup-setup-sha
+  - path: dist\$(TARGET)\rustup.msi
+    name: rustup-msi
+  - path: dist\$(TARGET)\rustup-msi.exe.sha256
+    name: rustup-msi-exe-sha
 
 deploy:
   - provider: S3
@@ -89,7 +93,7 @@ deploy:
     bucket: dev-static-rust-lang-org
     set_public: true
     region: us-west-1
-    artifact: rustup-init,rustup-init-sha,rustup-setup,rustup-setup-sha
+    artifact: rustup-init,rustup-init-sha,rustup-setup,rustup-setup-sha,rustup-msi,rustup-msi-exe-sha
     folder: rustup
     on:
       branch: master
@@ -102,7 +106,7 @@ deploy:
     bucket: static-rust-lang-org
     set_public: true
     region: us-west-1
-    artifact: rustup-init,rustup-init-sha,rustup-setup,rustup-setup-sha
+    artifact: rustup-init,rustup-init-sha,rustup-setup,rustup-setup-sha,rustup-msi,rustup-msi-exe-sha
     folder: rustup
     on:
       branch: stable

--- a/ci/prepare-deploy-appveyor.ps1
+++ b/ci/prepare-deploy-appveyor.ps1
@@ -6,11 +6,6 @@ if ($env:APPVEYOR_REPO_BRANCH -eq "auto") {
    exit 0
 }
 
-# Don't do anything for MSI (yet)
-if ($env:BUILD_MSI) {
-   exit 0
-}
-
 # Copy rustup-init to rustup-setup for backwards compatibility
 cp target\${env:TARGET}\release\rustup-init.exe target\${env:TARGET}release\rustup-setup.exe
 
@@ -20,9 +15,16 @@ Get-FileHash .\target\${env:TARGET}\release\* | ForEach-Object {[io.file]::Write
 # Prepare bins for upload
 $dest = "dist\$env:TARGET"
 md -Force "$dest"
-cp target\${env:TARGET}\release\rustup-init.exe "$dest/"
-cp target\${env:TARGET}\release\rustup-init.exe.sha256 "$dest/"
-cp target\${env:TARGET}\release\rustup-setup.exe "$dest/"
-cp target\${env:TARGET}\release\rustup-setup.exe.sha256 "$dest/"
+if ($env:BUILD_MSI) {
+    # MSI only needs the actual MSI installer and a hash of the embedded rustup.exe for the self update check
+    # This hash is different from rustup-init.exe.sha256 because it is built with the `msi-installed` feature flag
+    cp target\${env:TARGET}\release\rustup-init.exe.sha256 "$dest\rustup-msi.exe.sha256"
+    cp src\rustup-win-installer\msi\target\rustup.msi "$dest\"
+} else {
+    cp target\${env:TARGET}\release\rustup-init.exe "$dest\"
+    cp target\${env:TARGET}\release\rustup-init.exe.sha256 "$dest\"
+    cp target\${env:TARGET}\release\rustup-setup.exe "$dest\"
+    cp target\${env:TARGET}\release\rustup-setup.exe.sha256 "$dest\"
+}
 
 ls "$dest"

--- a/src/rustup-win-installer/Cargo.toml
+++ b/src/rustup-win-installer/Cargo.toml
@@ -8,6 +8,10 @@ build = "build.rs"
 name = "rustup_msi"
 crate-type = ["cdylib"]
 
+[features]
+# Prevents confusion and reduces build time (`rustup` will be built twice otherwise)
+default = ["rustup/msi-installed"]
+
 [dependencies]
 winapi = "0.2"
 rustup = { path = "../../", version = "0.6.1" }


### PR DESCRIPTION
This enables deployment of `rustup.msi` and the corresponding SHA of the embedded executable. I don't know exactly how the corresponding AppVeyor settings work, so whoever is responsible for the original setup should have a look at this, since I'm not able to test it locally.
