### PR TITLE
Disable anti-sudo check. #695

### DIFF
--- a/src/rustup-cli/self_update.rs
+++ b/src/rustup-cli/self_update.rs
@@ -196,7 +196,11 @@ pub fn install(no_prompt: bool, verbose: bool,
                mut opts: InstallOpts) -> Result<()> {
 
     try!(do_pre_install_sanity_checks());
-    try!(do_anti_sudo_check(no_prompt));
+    // FIXME: #695 This function is miscompiled and crashes.
+    // Even when I pin the compiler to an old nightly, 2016-08-10,
+    // which _does not crash_ on my machine, it still seems to be
+    // miscompiled on the deployed builds. I am very confused.
+    //try!(do_anti_sudo_check(no_prompt));
 
     if !no_prompt {
         let ref msg = try!(pre_install_msg(opts.no_modify_path));


### PR DESCRIPTION
Well, now I'm just desperate. I tried to deploy a new build where [travis was _definitely_ pinned to 2016-08-10](https://travis-ci.org/rust-lang-nursery/rustup.rs/jobs/155666869), a toolchain for which I can't reproduce the crash locally, but that build _still crashed_. I'm just disabling this function to see what happens now.

cc #695