### PR TITLE
Update to error-chain 0.5.0 to allow optional backtrace. #591

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,9 +1,32 @@
 [root]
-name = "rustup-win-installer"
+name = "rustup"
 version = "0.6.3"
 dependencies = [
- "rustup 0.6.3",
+ "clap 2.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "download 0.3.0",
+ "error-chain 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.4.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "markdown 0.1.2 (git+https://github.com/Diggsey/markdown.rs.git)",
+ "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.73 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustup-dist 0.6.3",
+ "rustup-mock 0.6.3",
+ "rustup-utils 0.6.3",
+ "scopeguard 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 2.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "user32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winreg 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -87,17 +110,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "clap"
-version = "2.10.4"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "term_size 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-segmentation 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "vec_map 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -173,7 +198,7 @@ dependencies = [
  "ca-loader 0.1.0",
  "curl 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_proxy 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "error-chain 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.1.0 (git+https://github.com/sfackler/rust-native-tls.git)",
@@ -192,7 +217,7 @@ dependencies = [
 
 [[package]]
 name = "error-chain"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -541,41 +566,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustup"
-version = "0.6.3"
-dependencies = [
- "clap 2.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "download 0.3.0",
- "error-chain 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.4.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "markdown 0.1.2 (git+https://github.com/Diggsey/markdown.rs.git)",
- "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.73 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustup-dist 0.6.3",
- "rustup-mock 0.6.3",
- "rustup-utils 0.6.3",
- "scopeguard 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 2.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "term 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "user32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winreg 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "rustup-dist"
 version = "0.6.3"
 dependencies = [
- "error-chain 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "gcc 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.4.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -622,7 +616,7 @@ version = "0.6.3"
 dependencies = [
  "advapi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "download 0.3.0",
- "error-chain 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "ole32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,32 +1,9 @@
 [root]
-name = "rustup"
+name = "rustup-win-installer"
 version = "0.6.3"
 dependencies = [
- "clap 2.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "download 0.3.0",
- "error-chain 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.4.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "markdown 0.1.2 (git+https://github.com/Diggsey/markdown.rs.git)",
- "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.73 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustup-dist 0.6.3",
- "rustup-mock 0.6.3",
- "rustup-utils 0.6.3",
- "scopeguard 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 2.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "term 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "user32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustup 0.6.3",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winreg 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -566,6 +543,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustup"
+version = "0.6.3"
+dependencies = [
+ "clap 2.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "download 0.3.0",
+ "error-chain 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.4.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "markdown 0.1.2 (git+https://github.com/Diggsey/markdown.rs.git)",
+ "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.73 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustup-dist 0.6.3",
+ "rustup-mock 0.6.3",
+ "rustup-utils 0.6.3",
+ "scopeguard 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 2.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "user32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winreg 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rustup-dist"
 version = "0.6.3"
 dependencies = [
@@ -975,7 +983,7 @@ dependencies = [
 "checksum base64 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ce110e5c96df1817009271c910626fa4b79c2f178d70f9857d768c3886ba6a0"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de1e760d7b6535af4241fca8bd8adf68e2e7edacc6b29f5d399050c5e48cf88c"
-"checksum clap 2.10.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3df6dcb3122b085b96399062f4fa59d69f4d0af50519944f2d76b7a7686629e3"
+"checksum clap 2.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "62db8e9e3ab6792670f99338be3dbc416f8728ba5d874c33e27aa9933e534512"
 "checksum cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0e3d6405328b6edb412158b3b7710e2634e23f3614b9bb1c412df7952489a626"
 "checksum core-foundation 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "20a6d0448d3a99d977ae4a2aa5a98d886a923e863e81ad9ff814645b6feb3bbd"
 "checksum core-foundation-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "05eed248dc504a5391c63794fe4fb64f46f071280afaa1b73308f3c0ce4574c5"
@@ -984,7 +992,7 @@ dependencies = [
 "checksum curl-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "780c1e295903f12cb0598d73703f850615f685eeeb4f2323fbd2911ef337da7e"
 "checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
 "checksum env_proxy 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f190d9208c08f9f0f608d9ba2530620b351d10e4bf2a62ac2292fe63380fbfb7"
-"checksum error-chain 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a8b6b917cc8ec29b15e925bc6faaaea9df5a91967cd0279ed14d11db1beb20db"
+"checksum error-chain 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bd5c82c815138e278b8dcdeffc49f27ea6ffb528403e9dea4194f2e3dd40b143"
 "checksum filetime 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "5363ab8e4139b8568a6237db5248646e5a8a2f89bd5ccb02092182b11fd3e922"
 "checksum flate2 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "3eeb481e957304178d2e782f2da1257f1434dfecbae883bafb61ada2a9fea3bb"
 "checksum gcc 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)" = "dcb000abd6df9df4c637f75190297ebe56c1d7e66b56bbf3b4aa7aece15f61a2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ msi-installed = []
 rustup-dist = { path = "src/rustup-dist", version = "0.6.3" }
 rustup-utils = { path = "src/rustup-utils", version = "0.6.3" }
 download = { path = "src/download" }
-error-chain = "0.4.0"
+error-chain = "0.5.0"
 clap = "2.2.4"
 regex = "0.1.41"
 url = "1.1.0"

--- a/src/download/Cargo.toml
+++ b/src/download/Cargo.toml
@@ -15,7 +15,7 @@ hyper-backend = ["hyper", "env_proxy", "native-tls", "openssl-sys"]
 rustls-backend = ["hyper", "env_proxy", "rustls", "lazy_static", "ca-loader"]
 
 [dependencies]
-error-chain = "0.4.0"
+error-chain = "0.5.0"
 url = "1.1"
 curl = { version = "0.3", optional = true }
 lazy_static = { version = "0.2", optional = true }

--- a/src/rustup-cli/common.rs
+++ b/src/rustup-cli/common.rs
@@ -353,9 +353,11 @@ pub fn report_error(e: &Error) {
     }
 
     if show_backtrace() {
-        info!("backtrace:");
-        println!("");
-        println!("{:?}", e.backtrace());
+        if let Some(backtrace) = e.backtrace() {
+            info!("backtrace:");
+            println!("");
+            println!("{:?}", backtrace);
+        }
     } else {
     }
 

--- a/src/rustup-dist/Cargo.toml
+++ b/src/rustup-dist/Cargo.toml
@@ -24,7 +24,7 @@ walkdir = "0.1.5"
 toml = "0.1.27"
 sha2 = "0.1.2"
 rustup-utils = { path = "../rustup-utils", version = "0.6.3" }
-error-chain = "0.4.0"
+error-chain = "0.5.0"
 rustup-mock = { path = "../rustup-mock", version = "0.6.3" }
 
 [target."cfg(windows)".dependencies]

--- a/src/rustup-utils/Cargo.toml
+++ b/src/rustup-utils/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 rand = "0.3.11"
 scopeguard = "0.1.2"
-error-chain = "0.4.0"
+error-chain = "0.5.0"
 libc = "0.2.0"
 rustc-serialize = "0.3.19"
 sha2 = "0.1.2"


### PR DESCRIPTION
Thought I'd give this a try. No test failures, and it does seem to short-circuit a bunch of system calls with `RUST_BACKTRACE=0`.