### PR TITLE
making rustup prepend cargo bin to path instead of append

### DIFF
--- a/src/rustup/toolchain.rs
+++ b/src/rustup/toolchain.rs
@@ -322,12 +322,12 @@ impl<'a> Toolchain<'a> {
         env_var::prepend_path(sysenv::LOADER_PATH, &new_path, cmd);
 
         // Prepend first cargo_home, then toolchain/bin to the PATH
-        let mut path_to_prepend = Vec::with_capacity(2);
+        let mut path_to_prepend = PathBuf::from("");
         if let Ok(cargo_home) = utils::cargo_home() {
             path_to_prepend.push(cargo_home.join("bin"));
         }
         path_to_prepend.push(self.path.join("bin"));
-        env_var::prepend_path("PATH", path_to_prepend, cmd);
+        env_var::prepend_path("PATH", path_to_prepend.as_path(), cmd);
     }
 
     pub fn doc_path(&self, relative: &str) -> Result<PathBuf> {

--- a/src/rustup/toolchain.rs
+++ b/src/rustup/toolchain.rs
@@ -321,13 +321,13 @@ impl<'a> Toolchain<'a> {
         }
         env_var::prepend_path(sysenv::LOADER_PATH, &new_path, cmd);
 
-        // Append first cargo_home, then toolchain/bin to the PATH
-        let mut path_to_append = Vec::with_capacity(2);
+        // Prepend first cargo_home, then toolchain/bin to the PATH
+        let mut path_to_prepend = Vec::with_capacity(2);
         if let Ok(cargo_home) = utils::cargo_home() {
-            path_to_append.push(cargo_home.join("bin"));
+            path_to_prepend.push(cargo_home.join("bin"));
         }
-        path_to_append.push(self.path.join("bin"));
-        env_var::append_path("PATH", path_to_append, cmd);
+        path_to_prepend.push(self.path.join("bin"));
+        env_var::prepend_path("PATH", path_to_prepend, cmd);
     }
 
     pub fn doc_path(&self, relative: &str) -> Result<PathBuf> {


### PR DESCRIPTION
A first attempt at fixing #475 

I'm not sure if the change is this simple because I'm honestly not sure how to test this one.
But I changed the Toolchain::set_ldpath to prepend instead of append.

If you could share some advice on how to test I'm more than willing to do so :)