### PR TITLE
Use released version of rustls dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,7 +178,7 @@ dependencies = [
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.1.0 (git+https://github.com/sfackler/rust-native-tls.git)",
  "openssl-sys 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustls 0.1.0 (git+https://github.com/ctz/rustls.git)",
+ "rustls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -502,11 +502,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ring"
-version = "0.1.0"
-source = "git+https://github.com/ctz/ring#9a468a7ac60268f4ec64b569c32bbc12d1554f6e"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "untrusted 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "untrusted 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -529,15 +529,15 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.1.0"
-source = "git+https://github.com/ctz/rustls.git#5b96b9c5ea7e0d45ee31387c488ecd2a6a02266f"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "ring 0.1.0 (git+https://github.com/ctz/ring)",
+ "ring 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "untrusted 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "webpki 0.1.0 (git+https://github.com/ctz/webpki)",
+ "untrusted 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webpki 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -864,7 +864,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "untrusted"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -932,13 +932,13 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.1.0"
-source = "git+https://github.com/ctz/webpki#c257d386d974ad5c1585984f7772ecbe3cff429f"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "ring 0.1.0 (git+https://github.com/ctz/ring)",
+ "ring 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "untrusted 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "untrusted 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1028,11 +1028,11 @@ dependencies = [
 "checksum rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "2791d88c6defac799c3f20d74f094ca33b9332612d9aef9078519c82e4fe04a5"
 "checksum regex 0.1.73 (registry+https://github.com/rust-lang/crates.io-index)" = "56b7ee9f764ecf412c6e2fff779bca4b22980517ae335a21aeaf4e32625a5df2"
 "checksum regex-syntax 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "31040aad7470ad9d8c46302dcffba337bb4289ca5da2e3cd6e37b64109a85199"
-"checksum ring 0.1.0 (git+https://github.com/ctz/ring)" = "<none>"
+"checksum ring 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ecf8f9a031706b6da124a7d9bc4e41054720a70c41337aab27ccb1d6e55ec86c"
 "checksum rustc-demangle 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c4c2d35b2ed94cec4fad26a36eee4d6eff394ce70a8ceea064b0b6ca42ea4cf0"
 "checksum rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)" = "6159e4e6e559c81bd706afe9c8fd68f547d3e851ce12e76b1de7914bab61691b"
 "checksum rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
-"checksum rustls 0.1.0 (git+https://github.com/ctz/rustls.git)" = "<none>"
+"checksum rustls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "be63398fa4474942eff3dd0d06413848d73a0a9c988b3984cca41e4f2f2bb18c"
 "checksum schannel 0.0.2 (git+https://github.com/sfackler/schannel-rs?branch=rewrite)" = "<none>"
 "checksum scopeguard 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "59a076157c1e2dc561d8de585151ee6965d910dd4dcb5dabb7ae3e83981a6c57"
 "checksum secur32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3f412dfa83308d893101dd59c10d6fda8283465976c28c287c5c855bf8d216bc"
@@ -1061,7 +1061,7 @@ dependencies = [
 "checksum unicode-normalization 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "26643a2f83bac55f1976fb716c10234485f9202dcd65cfbdf9da49867b271172"
 "checksum unicode-segmentation 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b905d0fc2a1f0befd86b0e72e31d1787944efef9d38b9358a9e92a69757f7e3b"
 "checksum unicode-width 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2d6722facc10989f63ee0e20a83cd4e1714a9ae11529403ac7e0afd069abc39e"
-"checksum untrusted 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7db5c188172b56840e937612d81bc6859c52f2fb2898d6cba443fb64b5160abd"
+"checksum untrusted 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5d9bc0e6e73a10975d1fbff8ac3541e221181b0d8998351600fb5523de634c0d"
 "checksum url 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8ab4ca6f0107350f41a59a51cb0e71a04d905bc6a29181d2cb42fa4f040c65c9"
 "checksum user32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6717129de5ac253f5642fc78a51d0c7de6f9f53d617fc94e9bae7f6e71cf5504"
 "checksum user32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ef4711d107b21b410a3a974b1204d9accc8b10dad75d8324b5d755de1617d47"
@@ -1070,7 +1070,7 @@ dependencies = [
 "checksum vec_map 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cac5efe5cb0fa14ec2f84f83c701c562ee63f6dcc680861b21d65c682adfb05f"
 "checksum wait-timeout 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3e8ab44ea5707ff5261a802e8be19697a2e342ecc55409b062c285fc4f624d05"
 "checksum walkdir 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "7ad450634b9022aeb0e8e7f1c79c1ded92d0fc5bee831033d148479771bd218d"
-"checksum webpki 0.1.0 (git+https://github.com/ctz/webpki)" = "<none>"
+"checksum webpki 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "813503a5985585e0812d430cd1328ee322f47f66629c8ed4ecab939cf9e92f91"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum winreg 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e63857fb213f619b4c4fff86b158285c76766aac7e7474967e92fb6dbbfeefe9"

--- a/src/download/Cargo.toml
+++ b/src/download/Cargo.toml
@@ -37,7 +37,7 @@ optional = true
 openssl-sys = { version = "0.7.11", optional = true }
 
 [dependencies.rustls]
-git = "https://github.com/ctz/rustls.git"
+version = "0.1.2"
 optional = true
 
 [dependencies.ca-loader]


### PR DESCRIPTION
Currently master fails to build with:

```
Updating git repository `https://github.com/ctz/ring`
error: failed to load source for a dependency on `ring`
Caused by:
  Unable to update https://github.com/ctz/ring#9a468a7a
Caused by:
  failed to clone into: /buildslave/target/cargo-home/git/db/ring-d33dffdb083ffa66
Caused by:
  failed to authenticate when downloading repository
attempted to find username/password via git's `credential.helper` support, but failed
To learn more, run the command again with --verbose.
```

I tracked `ring` down as a dependency of `rustls` in `download`. Updating `rustls` to the latest version (0.1.2) fixes the issue.

I'm not sure how unstable `rustls`'s API is, so I took the safe bet of clamping down to the exact version instead of relaxing to 0.1. Feel free to tell me to change it, though!