### PR TITLE
Fix checksum failures

### DIFF
--- a/src/rustup-cli/main.rs
+++ b/src/rustup-cli/main.rs
@@ -19,6 +19,7 @@ extern crate scopeguard;
 extern crate tempdir;
 extern crate sha2;
 extern crate markdown;
+extern crate toml;
 
 #[cfg(windows)]
 extern crate winapi;

--- a/src/rustup-dist/src/notifications.rs
+++ b/src/rustup-dist/src/notifications.rs
@@ -53,10 +53,10 @@ impl<'a> Notification<'a> {
             DownloadingComponent(_, _, _) |
             InstallingComponent(_, _, _) |
             ComponentAlreadyInstalled(_)  |
+            ManifestChecksumFailedHack |
             RollingBack | DownloadingManifest(_) => NotificationLevel::Info,
             CantReadUpdateHash(_) | ExtensionNotInstalled(_) |
-            MissingInstalledComponent(_) |
-            ManifestChecksumFailedHack => NotificationLevel::Warn,
+            MissingInstalledComponent(_) => NotificationLevel::Warn,
             NonFatalError(_) => NotificationLevel::Error,
         }
     }


### PR DESCRIPTION
Fix checksum failures with new self-update process

This changes the update process in the following ways: the current
version is read from the server at /rustup/stable-release.toml; if the
version is different from the running version then rustup downloads
the new release from the archives at /rustup/archive/$version/.

Fixes #524

This is intended to be a temporary solution until the full solution detailed [here](https://internals.rust-lang.org/t/future-updates-to-the-rustup-distribution-format/4196/1) is implemented.

r? @alexcrichton 