### PR TITLE
Completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,7 +87,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "clap"
-version = "2.15.0"
+version = "2.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -544,7 +544,7 @@ dependencies = [
 name = "rustup"
 version = "0.6.4"
 dependencies = [
- "clap 2.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "download 0.3.0",
  "error-chain 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -983,7 +983,7 @@ dependencies = [
 "checksum base64 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ce110e5c96df1817009271c910626fa4b79c2f178d70f9857d768c3886ba6a0"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de1e760d7b6535af4241fca8bd8adf68e2e7edacc6b29f5d399050c5e48cf88c"
-"checksum clap 2.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c3ad95014a5d1926493801463817b2e7e3ee64e051361a560f805c5320cd17b1"
+"checksum clap 2.16.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7d3f517329dfa6300c8415693c54e524f777dc470265bd73dfd1ff1699c3ee30"
 "checksum cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0e3d6405328b6edb412158b3b7710e2634e23f3614b9bb1c412df7952489a626"
 "checksum core-foundation 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "20a6d0448d3a99d977ae4a2aa5a98d886a923e863e81ad9ff814645b6feb3bbd"
 "checksum core-foundation-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "05eed248dc504a5391c63794fe4fb64f46f071280afaa1b73308f3c0ce4574c5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ rustls-backend = ["download/rustls-backend"]
 # Include in the default set to disable self-update and uninstall.
 no-self-update = []
 
-# Used to change behavior of self-update and uninstall if installed via MSI 
+# Used to change behavior of self-update and uninstall if installed via MSI
 msi-installed = []
 
 [dependencies]
@@ -36,7 +36,7 @@ rustup-dist = { path = "src/rustup-dist", version = "0.6.4" }
 rustup-utils = { path = "src/rustup-utils", version = "0.6.4" }
 download = { path = "src/download" }
 error-chain = "0.5.0"
-clap = "2.11.3"
+clap = "2.16.1"
 regex = "0.1.41"
 url = "1.1.0"
 term = "0.4.4"

--- a/README.md
+++ b/README.md
@@ -58,18 +58,36 @@ you are ready to Rust. If you decide Rust isn't your thing, you can
 completely remove it from your system by running `rustup self
 uninstall`.
 
-#### Enable tab completion for Zsh
+#### Enable tab completion for Bash, Fish, or Zsh
 
-Copy [`src/rustup-cli/zsh/_rustup`](https://github.com/rust-lang-nursery/rustup.rs/blob/master/src/rustup-cli/zsh/_rustup) into a directory, e.g. `~/.zfunc/`,
-then add the following line in your `~/.zshrc` before `compinit`:
+`rustup` now supports generating completion scripts for Bash, Fish,
+and Zsh. See `rustup help completions` for full details, but the
+gist is as simple as using one of the following:
+
+```
+# Bash
+$ rustup completions bash > /etc/bash_completions.d/rustup.bash-completion
+
+# Fish
+$ rustup completions fish > ~/.config/fish/completions/rustup.fish
+
+# Zsh
+$ rustup completions zsh > ~/.zfunc/_rustup
+```
+
+*Note:* you may need to restart your shell in order for the changes to take affect.
+
+*Note:* For Zsh, see additional details below
+
+#### Addtional Notes for Zsh
+
+One can alternatively copy [`src/rustup-cli/zsh/_rustup`](https://github.com/rust-lang-nursery/rustup.rs/blob/master/src/rustup-cli/zsh/_rustup) into a directory, e.g. `~/.zfunc/`.
+
+Regardless of method, you must then add the following line in your `~/.zshrc` before `compinit`:
 
 ```zsh
 fpath+=~/.zfunc
 ```
-
-#### Enable tab completion for Bash
-
-Waiting for [#278](https://github.com/rust-lang-nursery/rustup.rs/issues/278)
 
 ## How rustup works
 

--- a/src/rustup-cli/help.rs
+++ b/src/rustup-cli/help.rs
@@ -131,3 +131,71 @@ default browser.
 
 By default, it opens the documentation index. Use the various flags to
 open specific pieces of documentation.";
+
+pub static COMPLETIONS_HELP: &'static str =
+r"
+One can generate a completion script for `rustup` that is compatible with
+a given shell. The script is output on `stdout` allowing one to re-direct
+the output to the file of their choosing. Where you place the file will
+depend on which shell, and which operating system you are using. Your
+particular configuration may also determine where these scripts need
+to be placed.
+
+Here are some common set ups for the three supported shells under
+Unix and similar operating systems (such as GNU/Linux).
+
+BASH:
+
+Completion files are commonly stored in `/etc/bash_completion.d/`
+
+Run the command:
+
+`rustup completions bash > /etc/bash_completion.d/rustup.bash-completion`
+
+This installs the completion script. You may have to log out and log
+back in to your shell session for the changes to take affect.
+
+FISH:
+
+Fish completion files are commonly stored in
+`$HOME/.config/fish/completions`
+
+Run the command:
+`rustup completions fish > ~/.config/fish/completions/rustup.fish`
+
+This installs the completion script. You may have to log out and log
+back in to your shell session for the changes to take affect.
+
+ZSH:
+
+ZSH completions are commonly stored in any directory listed in your
+`$fpath` variable. To use these completions, you must either add the
+generated script to one of those directories, or add your own
+to this list.
+
+Adding a custom directory is often the safest best if you're unsure
+of which directory to use. First create the directory, for this
+example we'll create a hidden directory inside our `$HOME` directory
+
+`mkdir ~/.zfunc`
+
+Then add the following lines to your `.zshrc` just before `compinit`
+
+`fpath+=~/.zfunc`
+
+Now you can install the completions script using the following command
+
+`rustup completions zsh > ~/.zfunc/_rustup`
+
+You must then either log out and log back in, or simply run
+
+`exec zsh`
+
+For the new completions to take affect.
+
+CUSTOM LOCATIONS:
+
+Alternatively, you could save these files to the place of your choosing,
+such as a custom directory inside your $HOME. Doing so will require you
+to add the proper directives, such as `source`ing inside your login
+script. Consult your shells documentation for how to add such directives.";


### PR DESCRIPTION
This commit adds a command line option to generate completion scripts, as well as updates `clap` to 2.16.0 which adds ZSH completion support.

Here's a gif of the new ZSH support and the new `rustup completions` subcommand backing it.

![rustup_zsh](https://cloud.githubusercontent.com/assets/6942134/19633417/6f9fc3ea-997f-11e6-89ce-21a157709bde.gif)

Specifically this commit adds 

```
$ rustup completions <shell>
```

Finally, this PR adds some additional help documentation on the `completions` command, and changes the `README.md` slightly to reflect the new additions.

Some notes about the ZSH script generated by `clap`, it supports, subcommands, flags, args, and options. The options also automatically list their `possible_values`, and will automatically *not* list any arguments they `conflict` with. This may not be too applicable to `rustup` since I don't think many of those options are used, but it's good to note for future reference.

Also, positional arguments, such as `toolchain` in a few of the subcommands is changed to uppercase ASCII by `clap` in order to differentiate.

Edit: removed verbiage about `--completions`