### PR TITLE
Fix the production definition of RUSTUP_UPDATE_ROOT

### DIFF
--- a/src/rustup-cli/self_update.rs
+++ b/src/rustup-cli/self_update.rs
@@ -171,7 +171,7 @@ static TOOLS: &'static [&'static str]
     = &["rustc", "rustdoc", "cargo", "rust-lldb", "rust-gdb"];
 
 static UPDATE_ROOT: &'static str
-    = "https://static.rust-lang.org/rustup/dist";
+    = "https://static.rust-lang.org/rustup";
 
 /// CARGO_HOME suitable for display, possibly with $HOME
 /// substituted for the directory prefix


### PR DESCRIPTION
The update root is one directory higher now. That's where the
stable-release.toml file, and the archive directory live.