### PR TITLE
Correctly "detect" host endianness on MIPS

### DIFF
--- a/src/rustup-dist/src/dist.rs
+++ b/src/rustup-dist/src/dist.rs
@@ -82,6 +82,15 @@ static LIST_OSES: &'static [&'static str] = &["pc-windows",
 static LIST_ENVS: &'static [&'static str] =
     &["gnu", "msvc", "gnueabi", "gnueabihf", "androideabi", "musl"];
 
+// MIPS platforms don't indicate endianness in uname, however binaries only
+// run on boxes with the same endianness, as expected.
+// Hence we could distinguish between the variants with compile-time cfg()
+// attributes alone.
+#[cfg(target_endian = "big")]
+const TRIPLE_MIPS_UNKNOWN_LINUX_GNU: &'static str = "mips-unknown-linux-gnu";
+#[cfg(target_endian = "little")]
+const TRIPLE_MIPS_UNKNOWN_LINUX_GNU: &'static str = "mipsel-unknown-linux-gnu";
+
 impl TargetTriple {
     pub fn from_str(name: &str) -> Self {
         TargetTriple(name.to_string())
@@ -150,8 +159,7 @@ impl TargetTriple {
             let host_triple = match (sysname, machine) {
                 (b"Linux", b"x86_64") => Some("x86_64-unknown-linux-gnu"),
                 (b"Linux", b"i686") => Some("i686-unknown-linux-gnu"),
-                (b"Linux", b"mips") => Some("mips-unknown-linux-gnu"),
-                (b"Linux", b"mipsel") => Some("mipsel-unknown-linux-gnu"),
+                (b"Linux", b"mips") => Some(TRIPLE_MIPS_UNKNOWN_LINUX_GNU),
                 (b"Linux", b"arm") => Some("arm-unknown-linux-gnueabi"),
                 (b"Linux", b"aarch64") => Some("aarch64-unknown-linux-gnu"),
                 (b"Darwin", b"x86_64") => Some("x86_64-apple-darwin"),


### PR DESCRIPTION
Counter-intuitively, Linux on MIPS reports the same machine name in
`uname(2)` output, regardless of endianness. So the current check is
bogus, and will fail on little-endian boxes. However, because the endianness
is not runtime reconfigurable, binaries are guaranteed to only work on
platforms with the same endianness. Hence, we can rely on compile-time
`cfg()` checks to provide the correct host triple, despite the kernel
not providing that information.